### PR TITLE
BW-1342 Support for passing entity field and ID to CBAS

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { h } from 'react-hyperscript-helpers'
+import { h, input } from 'react-hyperscript-helpers'
 import TextAreaAutosize from 'react-textarea-autosize'
 import colors from 'src/libs/colors'
 import { forwardRefWithName, useLabelAssert } from 'src/libs/react-utils'
@@ -48,4 +48,24 @@ export const TextArea = forwardRefWithName('TextArea', ({ onChange, autosize = f
     style: styles.textarea,
     onChange: onChange ? (e => onChange(nativeOnChange ? e : e.target.value)) : undefined
   }, props))
+})
+
+export const TextInput = forwardRefWithName('TextInput', ({ onChange, nativeOnChange = false, ...props }, ref) => {
+  useLabelAssert('TextInput', { ...props, allowId: true })
+
+  return input({
+    ..._.merge({
+      className: 'focus-style',
+      onChange: onChange ? e => onChange(nativeOnChange ? e : e.target.value) : undefined,
+      style: {
+        ...styles.input,
+        width: '100%',
+        paddingLeft: '1rem', paddingRight: '1rem',
+        fontWeight: 400, fontSize: 14,
+        backgroundColor: props.disabled ? colors.light() : undefined
+      }
+    }, props),
+    // the ref does not get added to the props correctly when inside of _.merge
+    ref
+  })
 })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -3,6 +3,9 @@ import { getConfig } from 'src/libs/config'
 import { ajaxOverridesStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
+
+const jsonBody = body => ({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
+
 // Allows use of ajaxOverrideStore to stub responses for testing
 const withInstrumentation = wrappedFetch => (...args) => {
   return _.flow(
@@ -59,6 +62,12 @@ const Cbas = signal => ({
       formData.set('workflow_url', workflowUrl)
       formData.set('workflow_params', inputs)
       const res = await fetchCbas(`runs`, { body: formData, signal, method: 'POST' })
+      return res.json()
+    }
+  },
+  runSets: {
+    post: async payload => {
+      const res = await fetchCbas(`run_sets`, _.mergeAll([{ signal, method: 'POST' }, jsonBody(payload)]))
       return res.json()
     }
   }

--- a/src/pages/SubmitWorkflow.js
+++ b/src/pages/SubmitWorkflow.js
@@ -13,7 +13,9 @@ import { WorkflowSource } from 'src/pages/WorkflowSource'
 export const SubmitWorkflow = () => {
   // State
   const [workflowUrl, setWorkflowUrl] = useState()
-  const [workflowInputs, setWorkflowInputs] = useState()
+  const [workflowInputsDefinition, setWorkflowInputsDefinition] = useState()
+  const [entityType, setEntityType] = useState('')
+  const [entityId, setEntityId] = useState('')
   const [showInputsPage, setShowInputsPage] = useState(false)
   const [cbasStatus, setCbasStatus] = useState()
   const [runsData, setRunsData] = useState()
@@ -41,7 +43,16 @@ export const SubmitWorkflow = () => {
 
   const submitRun = async () => {
     try {
-      await Ajax(signal).Cbas.runs.post(workflowUrl, workflowInputs)
+      const runSetsPayload = {
+        workflow_url: workflowUrl,
+        workflow_param_definitions: JSON.parse(workflowInputsDefinition),
+        wds_entities: {
+          entity_type: entityType,
+          entity_ids: JSON.parse(entityId)
+        }
+      }
+
+      await Ajax(signal).Cbas.runSets.post(runSetsPayload)
       notify('success', 'Workflow successfully submitted', { message: 'You may check on the progress of workflow on this page anytime.', timeout: 5000 })
       Nav.goToPath('previous-runs')
     } catch (error) {
@@ -71,7 +82,7 @@ export const SubmitWorkflow = () => {
           h(SavedWorkflows, { runsData })
         ]),
         showInputsPage && h(Fragment, [
-          h(WorkflowInputs, { workflowUrl, workflowInputs, setWorkflowInputs }),
+          h(WorkflowInputs, { workflowUrl, entityType, setEntityType, entityId, setEntityId, workflowInputsDefinition, setWorkflowInputsDefinition }),
           div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'space-between' } }, [
             'Outputs will be saved to cloud storage',
             div([
@@ -80,7 +91,7 @@ export const SubmitWorkflow = () => {
               }, ['Change selected workflow']),
               h(ButtonPrimary, {
                 style: { marginLeft: '1rem' },
-                disabled: !workflowInputs,
+                disabled: !workflowInputsDefinition,
                 onClick: () => submitRun()
               }, ['Run workflow'])
             ])

--- a/src/pages/WorkflowInputs.js
+++ b/src/pages/WorkflowInputs.js
@@ -1,28 +1,73 @@
 import { Fragment } from 'react'
 import { div, h, h3, span } from 'react-hyperscript-helpers'
 import { IdContainer } from 'src/components/common'
-import { TextArea } from 'src/components/input'
+import { TextArea, TextInput } from 'src/components/input'
 import { FormLabel } from 'src/libs/form'
 
 
-export const WorkflowInputs = ({ workflowUrl, workflowInputs, setWorkflowInputs }) => {
+export const WorkflowInputs = ({ workflowUrl, entityType, setEntityType, entityId, setEntityId, workflowInputsDefinition, setWorkflowInputsDefinition }) => {
+  // used as placeholder to let users know expected structure of inputs definition
+  const inputMappingExample = '\n[\n' +
+    '\t{\n' +
+    '    \t"parameter_name": "workflow_input_foo_rating",\n' +
+    '      \t"parameter_type": "String",\n' +
+    '      \t"source": {\n' +
+    '        \t"type": "entity_lookup",\n' +
+    '        \t"entity_attribute": "entity_field_foo_rating"\n' +
+    '      \t}\n' +
+    '    },\n' +
+    '    {\n' +
+    '      \t"parameter_name": "workflow_input_foo_id",\n' +
+    '      \t"parameter_type": "Integer",\n' +
+    '      \t"source": {\n' +
+    '        \t"type": "literal",\n' +
+    '        \t"param_value": "123"\n' +
+    '      \t}\n' +
+    '    }\n' +
+    ']'
+
   return div([
     div({ style: { marginTop: '2rem' } }, [
       span({ style: { fontWeight: 'bold' } }, ['Using workflow ']),
       span([workflowUrl])
     ]),
     div({ style: { marginTop: '2rem' } }, [
-      h3(['Provide inputs JSON file']),
+      h3(['Provide Inputs']),
       div([
-        'Copy and paste your JSON file below',
+        div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+          div([
+            h(IdContainer, [id => h(Fragment, [
+              h(FormLabel, { htmlFor: id }, ['Entity Type']),
+              h(TextInput, {
+                id,
+                style: { display: 'block', width: '100ex' },
+                placeholder: 'FOO',
+                value: entityType,
+                onChange: setEntityType
+              })
+            ])])
+          ]),
+          div([
+            h(IdContainer, [id => h(Fragment, [
+              h(FormLabel, { htmlFor: id }, ['Entity ID(s)']),
+              h(TextInput, {
+                id,
+                style: { display: 'block', width: '100ex' },
+                placeholder: '["F0011111-1111-1111-1111-111111111111"]',
+                value: entityId,
+                onChange: setEntityId
+              })
+            ])])
+          ])
+        ]),
         h(IdContainer, [id => h(Fragment, [
-          h(FormLabel, { htmlFor: id }),
+          h(FormLabel, { htmlFor: id }, ['Inputs definition']),
           h(TextArea, {
             id,
-            style: { height: 100 },
-            placeholder: 'Paste your JSON inputs here',
-            value: workflowInputs,
-            onChange: setWorkflowInputs
+            style: { height: 360 },
+            placeholder: `Paste your JSON input mapping here. For example,${inputMappingExample}`,
+            value: workflowInputsDefinition,
+            onChange: setWorkflowInputsDefinition
           })
         ])])
       ])

--- a/src/pages/WorkflowInputs.js
+++ b/src/pages/WorkflowInputs.js
@@ -8,24 +8,24 @@ import { FormLabel } from 'src/libs/form'
 export const WorkflowInputs = ({ workflowUrl, entityType, setEntityType, entityId, setEntityId, workflowInputsDefinition, setWorkflowInputsDefinition }) => {
   // used as placeholder to let users know expected structure of inputs definition.
   // To be removed later when we design UI for entering the input definition.
-  const inputMappingExample = '\n[\n' +
-    '\t{\n' +
-    '    \t"parameter_name": "workflow_input_foo_rating",\n' +
-    '      \t"parameter_type": "String",\n' +
-    '      \t"source": {\n' +
-    '        \t"type": "entity_lookup",\n' +
-    '        \t"entity_attribute": "entity_field_foo_rating"\n' +
-    '      \t}\n' +
-    '    },\n' +
-    '    {\n' +
-    '      \t"parameter_name": "workflow_input_foo_id",\n' +
-    '      \t"parameter_type": "Int",\n' +
-    '      \t"source": {\n' +
-    '        \t"type": "literal",\n' +
-    '        \t"param_value": "123"\n' +
-    '      \t}\n' +
-    '    }\n' +
-    ']'
+  const inputMappingExample = [
+    {
+      parameter_name: 'workflow_input_foo',
+      parameter_type: 'String',
+      source: {
+        type: 'literal',
+        entity_attribute: 'hello world'
+      }
+    },
+    {
+      parameter_name: 'workflow_input_foo_rating',
+      parameter_type: 'Int',
+      source: {
+        type: 'entity_lookup',
+        entity_attribute: 'entity_field_foo_rating'
+      }
+    }
+  ]
 
   return div([
     div({ style: { marginTop: '2rem' } }, [
@@ -66,7 +66,7 @@ export const WorkflowInputs = ({ workflowUrl, entityType, setEntityType, entityI
           h(TextArea, {
             id,
             style: { height: 360 },
-            placeholder: `Paste your JSON input mapping here. For example,${inputMappingExample}`,
+            placeholder: `Paste your JSON input mapping here. For example,\n ${JSON.stringify(inputMappingExample, null, 4)}`,
             value: workflowInputsDefinition,
             onChange: setWorkflowInputsDefinition
           })

--- a/src/pages/WorkflowInputs.js
+++ b/src/pages/WorkflowInputs.js
@@ -6,7 +6,8 @@ import { FormLabel } from 'src/libs/form'
 
 
 export const WorkflowInputs = ({ workflowUrl, entityType, setEntityType, entityId, setEntityId, workflowInputsDefinition, setWorkflowInputsDefinition }) => {
-  // used as placeholder to let users know expected structure of inputs definition
+  // used as placeholder to let users know expected structure of inputs definition.
+  // To be removed later when we design UI for entering the input definition.
   const inputMappingExample = '\n[\n' +
     '\t{\n' +
     '    \t"parameter_name": "workflow_input_foo_rating",\n' +
@@ -18,7 +19,7 @@ export const WorkflowInputs = ({ workflowUrl, entityType, setEntityType, entityI
     '    },\n' +
     '    {\n' +
     '      \t"parameter_name": "workflow_input_foo_id",\n' +
-    '      \t"parameter_type": "Integer",\n' +
+    '      \t"parameter_type": "Int",\n' +
     '      \t"source": {\n' +
     '        \t"type": "literal",\n' +
     '        \t"param_value": "123"\n' +


### PR DESCRIPTION
Note to reviewers: `TextInput` in `input.js` is copied from Terra UI

Testing: Local against local CBAS with Chris' changes from [PR #33](https://github.com/DataBiosphere/cbas/pull/33)

Screenshot of what the new inputs page looks like. The placeholders are added to let user know what is the expected structure of input:
<img src="https://user-images.githubusercontent.com/16748522/185186248-3fb714f8-e0c2-432f-8157-46da6ea81de0.png" width="70%" height="70%">

After filling up the fields:
![Screen Shot 2022-08-17 at 11 47 02 AM](https://user-images.githubusercontent.com/16748522/185186457-4414ccfa-e04c-410f-9a60-77e1892fdf48.png)

Successful response from CBAS after submitting the workflow:
![Screen Shot 2022-08-17 at 11 47 59 AM](https://user-images.githubusercontent.com/16748522/185186552-79325588-90ec-49c6-aa7d-fbfe11214b06.png)


Closes https://broadworkbench.atlassian.net/browse/BW-1342