### PR TITLE
[BW-1376] Add workflow url and workflow inputs back

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -56,13 +56,6 @@ const Cbas = signal => ({
     get: async () => {
       const res = await fetchCbas(`runs`, { signal, method: 'GET' })
       return res.json()
-    },
-    post: async (workflowUrl, inputs) => {
-      const formData = new FormData()
-      formData.set('workflow_url', workflowUrl)
-      formData.set('workflow_params', inputs)
-      const res = await fetchCbas(`runs`, { body: formData, signal, method: 'POST' })
-      return res.json()
     }
   },
   runSets: {

--- a/src/pages/SavedWorkflows.js
+++ b/src/pages/SavedWorkflows.js
@@ -2,11 +2,12 @@ import _ from 'lodash/fp'
 import { useState } from 'react'
 import { div, h, h3 } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
+import { ButtonOutline } from 'src/components/common'
 import { FlexTable, Sortable, TextCell } from 'src/components/table'
 import * as Utils from 'src/libs/utils'
 
 
-export const SavedWorkflows = ({ runsData }) => {
+export const SavedWorkflows = ({ runsData, setWorkflowUrl, setShowInputsPage }) => {
   // State
   const [sort, setSort] = useState({ field: 'submissionTimestamp', direction: 'desc' })
 
@@ -25,10 +26,10 @@ export const SavedWorkflows = ({ runsData }) => {
           columns: [
             {
               size: { basis: 500 },
-              field: 'workflowName',
-              headerRenderer: () => h(Sortable, { sort, field: 'workflowName', onSort: setSort }, ['Workflow Name']),
+              field: 'workflowUrl',
+              headerRenderer: () => h(Sortable, { sort, field: 'workflowUrl', onSort: setSort }, ['Workflow Link']),
               cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, [sortedPreviousRuns[rowIndex].name])
+                return h(TextCell, [sortedPreviousRuns[rowIndex].workflow_url])
               }
             },
             {
@@ -37,6 +38,19 @@ export const SavedWorkflows = ({ runsData }) => {
               headerRenderer: () => h(Sortable, { sort, field: 'submissionTimestamp', onSort: setSort }, ['Last Run']),
               cellRenderer: ({ rowIndex }) => {
                 return h(TextCell, [Utils.makeCompleteDate(sortedPreviousRuns[rowIndex].submission_date)])
+              }
+            },
+            {
+              size: { basis: 190, grow: 0 },
+              field: 'useWorkflowButton',
+              headerRenderer: () => '',
+              cellRenderer: ({ rowIndex }) => {
+                return h(ButtonOutline, {
+                  onClick: () => {
+                    setWorkflowUrl(sortedPreviousRuns[rowIndex].workflow_url)
+                    setShowInputsPage(true)
+                  }
+                }, ['Use Workflow'])
               }
             }
           ]

--- a/src/pages/SubmitWorkflow.js
+++ b/src/pages/SubmitWorkflow.js
@@ -79,7 +79,7 @@ export const SubmitWorkflow = () => {
               onClick: () => setShowInputsPage(true)
             }, ['Use workflow'])
           ]),
-          h(SavedWorkflows, { runsData })
+          h(SavedWorkflows, { runsData, setWorkflowUrl, setShowInputsPage })
         ]),
         showInputsPage && h(Fragment, [
           h(WorkflowInputs, { workflowUrl, entityType, setEntityType, entityId, setEntityId, workflowInputsDefinition, setWorkflowInputsDefinition }),


### PR DESCRIPTION
Screenshots from local testing:
<img src="https://user-images.githubusercontent.com/16748522/191374936-89ce798c-3797-4103-8b0a-73cf10e2bf69.png" width=70% height=70%>

Since CBAS doesn't store workflow names yet, the decision made was to show Run ID for now ([see Slack thread](https://broadinstitute.slack.com/archives/G01CVT4GJ8H/p1663346166577329))
<img src="https://user-images.githubusercontent.com/16748522/191374970-fb4e322b-3446-44b1-80a5-867275bc43dc.png" width=70% height=70%>
