### PR TITLE
WX-831 Navigate to and from workflow dashboard

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -69,11 +69,11 @@ const Cbas = signal => ({
 })
 
 const Cromwell = signal => ({
-  runs: runId => {
+  workflows: workflowId => {
     return {
       metadata: async (includeKey, excludeKey) => {
         const keyParams = qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })
-        const res = await fetchCromwell(`${runId}/metadata?${keyParams}`, { signal, method: 'GET' })
+        const res = await fetchCromwell(`${workflowId}/metadata?${keyParams}`, { signal, method: 'GET' })
         return res.json()
       }
     }

--- a/src/pages/PreviousRuns.js
+++ b/src/pages/PreviousRuns.js
@@ -68,7 +68,7 @@ export const PreviousRuns = () => {
                 headerRenderer: () => h(Sortable, { sort, field: 'run_id', onSort: setSort }, ['Run ID']),
                 cellRenderer: ({ rowIndex }) => {
                   const run = paginatedPreviousRuns[rowIndex]
-                  return h(Link, { 
+                  return h(Link, {
                     onClick: () => Nav.goToPath('workflow-dashboard', { workflowId: run.engine_id })
                   }, [run.run_id])
                 }

--- a/src/pages/PreviousRuns.js
+++ b/src/pages/PreviousRuns.js
@@ -67,7 +67,10 @@ export const PreviousRuns = () => {
                 field: 'run_id',
                 headerRenderer: () => h(Sortable, { sort, field: 'run_id', onSort: setSort }, ['Run ID']),
                 cellRenderer: ({ rowIndex }) => {
-                  return h(TextCell, [paginatedPreviousRuns[rowIndex].run_id])
+                  const run = paginatedPreviousRuns[rowIndex]
+                  return h(Link, { 
+                    onClick: () => Nav.goToPath('workflow-dashboard', { workflowId: run.engine_id })
+                  }, [run.run_id])
                 }
               },
               {

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -78,7 +78,7 @@ const WorkflowDashboard = (({ namespace, name, submissionId, workflowId }, _ref)
       const excludeKey = []
 
       const timeBefore = Date.now()
-      const metadata = await Ajax(signal).Cromwell.runs(workflowId).metadata({ includeKey, excludeKey })
+      const metadata = await Ajax(signal).Cromwell.workflows(workflowId).metadata({ includeKey, excludeKey })
       setWorkflow(metadata)
       setFetchTime(Date.now() - timeBefore)
 

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -12,6 +12,7 @@ import {
 //import UriViewer from 'src/components/UriViewer'
 import WDLViewer from 'src/components/WDLViewer'
 import { Ajax } from 'src/libs/ajax'
+import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -148,6 +149,8 @@ const WorkflowDashboard = (({ namespace, name, submissionId, workflowId }, _ref)
           ]),
           makeSection('Links', [
             div({ style: { display: 'flex', flexFlow: 'row wrap', marginTop: '0.5rem', lineHeight: '2rem' } }, [
+              h(Link, { onClick: () => Nav.goToPath('previous-runs') }, "See Previous Runs")
+
               //  Q4-2022 Disable log-viewing
               // h(Link, {
               //   onClick: () => setShowLog(true),
@@ -216,7 +219,7 @@ const WorkflowDashboard = (({ namespace, name, submissionId, workflowId }, _ref)
 export const navPaths = [
   {
     name: 'workflow-dashboard',
-    path: '/job-history/:workflowId',
+    path: '/previous-runs/:workflowId/dashboard',
     component: WorkflowDashboard,
     title: ({ name }) => `${name} - Workflow Dashboard`
   }

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -149,7 +149,7 @@ const WorkflowDashboard = (({ namespace, name, submissionId, workflowId }, _ref)
           ]),
           makeSection('Links', [
             div({ style: { display: 'flex', flexFlow: 'row wrap', marginTop: '0.5rem', lineHeight: '2rem' } }, [
-              h(Link, { onClick: () => Nav.goToPath('previous-runs') }, "See Previous Runs")
+              h(Link, { onClick: () => Nav.goToPath('previous-runs') }, 'See Previous Runs')
 
               //  Q4-2022 Disable log-viewing
               // h(Link, {


### PR DESCRIPTION
This PR creates links from the Previous Runs page to each workflow's dashboard, and back. 

It's a little confusing because the UUID you click on to get to the dashboard is the CBAS run id, and the UUID in the URL for the dashboard is the engine id (Cromwell workflow id). Given that these pages are about to change, I decided to leave it as-is until the dust settles. If we decide on a final destination for URL structure before this PR merges I am happy to update it.