### PR TITLE
[WM-1580] remove extra submission details header

### DIFF
--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -1,9 +1,9 @@
 import { filter, isEmpty, map, merge, orderBy } from 'lodash/fp'
 import { useMemo, useState } from 'react'
-import { div, h, h1, h2, h3 } from 'react-hyperscript-helpers'
+import { div, h, h2, h3 } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
 import { AutoSizer } from 'react-virtualized'
-import { ButtonOutline, ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
+import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { HeaderSection, SubmitNewWorkflowButton } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
@@ -131,13 +131,6 @@ export const SubmissionDetails = ({ submissionId }) => {
         position: 'relative'
       }
     }, [
-      div({ style: { marginLeft: '4em', display: 'flex', marginTop: '0.5rem', justifyContent: 'space-between' } }, [
-        h1(['Submission Details']),
-        h(ButtonOutline, {
-          style: { margin: '2em' },
-          onClick: () => goToPath('root')
-        }, ['Submit a new workflow'])
-      ]),
       div({ style: { marginLeft: '4em', lineHeight: 1.25 } }, [
         header,
         h2(['Submission name: ', specifyRunSet[0]?.run_set_name]),


### PR DESCRIPTION
this PR removes a duplicated header on the Submission Details page. The duplicate got there during a confusing merge conflict resolution.

Before:

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/5531017/208997655-ae8bca84-19b8-4bf7-ba25-07fa7f0869a2.png">

After:

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/5531017/208997733-327e9366-e21a-4fbb-a6be-9677b010c1dc.png">

