### PR TITLE
[WM-1651] Display message for Inputs tab when no records are available 

### DIFF
--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -11,6 +11,7 @@ import { Ajax } from 'src/libs/ajax'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
+import { maybeParseJSON } from 'src/libs/utils'
 import * as Utils from 'src/libs/utils'
 
 
@@ -71,8 +72,8 @@ export const SubmissionConfig = ({ methodId }) => {
     try {
       const runSet = await Ajax(signal).Cbas.runSets.getForMethod(methodId, 1)
       const newRunSetData = runSet.run_sets[0]
-      setConfiguredInputDefinition(JSON.parse(newRunSetData.input_definition))
-      setConfiguredOutputDefinition(JSON.parse(newRunSetData.output_definition))
+      setConfiguredInputDefinition(maybeParseJSON(newRunSetData.input_definition))
+      setConfiguredOutputDefinition(maybeParseJSON(newRunSetData.output_definition))
       setSelectedRecordType(newRunSetData.record_type)
       return newRunSetData
     } catch (error) {
@@ -205,11 +206,11 @@ export const SubmissionConfig = ({ methodId }) => {
   }
 
   const renderInputs = () => {
-    return configuredInputDefinition ? h(inputsTable, {
+    return configuredInputDefinition && recordTypes && records.length ? h(inputsTable, {
       configuredInputDefinition, setConfiguredInputDefinition,
       inputTableSort, setInputTableSort,
       selectedDataTable: _.keyBy('name', recordTypes)[selectedRecordType]
-    }) : 'No configured input definition...'
+    }) : 'No data table rows available or input definition is not configured...'
   }
 
   const renderOutputs = () => {


### PR DESCRIPTION
Tested locally:
When there is no records found for record type, instead of showing a blank screen users will see below message (just like we show for Select data tab)
![Screen Shot 2023-01-23 at 5 30 27 PM](https://user-images.githubusercontent.com/16748522/214164605-f612dcb8-8628-4f7c-b23a-feda42df4aec.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1651