### PR TITLE
[WM-1653] Auto refresh Submission History & Details pages

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -12,7 +12,7 @@ import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
 
-export const AutoRefreshTimeout = 1000 * 60 // 1 minute
+export const AutoRefreshInterval = 1000 * 60 // 1 minute
 
 const iconSize = 24
 export const addCountSuffix = (label, count = undefined) => {

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -12,6 +12,8 @@ import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
 
+export const AutoRefreshTimeout = 1000 * 60 // 1 minute
+
 const iconSize = 24
 export const addCountSuffix = (label, count = undefined) => {
   return label + (count === undefined ? '' : `: ${count}`)

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -6,7 +6,7 @@ import { AutoSizer } from 'react-virtualized'
 import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
-import { makeStatusLine } from 'src/components/submission-common'
+import { AutoRefreshTimeout, makeStatusLine } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -92,9 +92,9 @@ export const SubmissionDetails = ({ submissionId }) => {
       const runs = runsResponse?.runs
       setRunsData(runs)
 
-      // only refresh if there are Runs in non-terminal state. Refresh interval is 1 min
+      // only refresh if there are Runs in non-terminal state
       if (_.some(({ state }) => !isRunInTerminalState(state), runs)) {
-        scheduledRefresh.current = setTimeout(refresh, 1000 * 60)
+        scheduledRefresh.current = setTimeout(refresh, AutoRefreshTimeout)
       }
     } catch (error) {
       notify('error', 'Error loading previous runs', { detail: await (error instanceof Response ? error.text() : error) })

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -6,7 +6,7 @@ import { AutoSizer } from 'react-virtualized'
 import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
-import { AutoRefreshTimeout, makeStatusLine } from 'src/components/submission-common'
+import { AutoRefreshInterval, makeStatusLine } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -94,7 +94,7 @@ export const SubmissionDetails = ({ submissionId }) => {
 
       // only refresh if there are Runs in non-terminal state
       if (_.some(({ state }) => !isRunInTerminalState(state), runs)) {
-        scheduledRefresh.current = setTimeout(refresh, AutoRefreshTimeout)
+        scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
       }
     } catch (error) {
       notify('error', 'Error loading previous runs', { detail: await (error instanceof Response ? error.text() : error) })

--- a/src/pages/SubmissionHistory/SubmissionHistory.js
+++ b/src/pages/SubmissionHistory/SubmissionHistory.js
@@ -4,7 +4,7 @@ import { div, h, h2 } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonOutline, Link, Navbar } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { makeStatusLine, statusType } from 'src/components/submission-common'
+import { AutoRefreshTimeout, makeStatusLine, statusType } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import * as Nav from 'src/libs/nav'
@@ -43,9 +43,9 @@ export const SubmissionHistory = () => {
       const mergedRunSets = _.map(r => _.merge(r, { duration: runSetDuration(r) }), runSets.run_sets)
       setRunSetData(mergedRunSets)
 
-      // only refresh if there are Run Sets in non-terminal state. Refresh interval is 1 min
+      // only refresh if there are Run Sets in non-terminal state
       if (_.some(({ state }) => !isRunSetInTerminalState(state), mergedRunSets)) {
-        scheduledRefresh.current = setTimeout(refresh, 1000 * 60)
+        scheduledRefresh.current = setTimeout(refresh, AutoRefreshTimeout)
       }
     } catch (error) {
       notify('error', 'Error loading previous run sets', { detail: await (error instanceof Response ? error.text() : error) })

--- a/src/pages/SubmissionHistory/SubmissionHistory.js
+++ b/src/pages/SubmissionHistory/SubmissionHistory.js
@@ -4,7 +4,7 @@ import { div, h, h2 } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonOutline, Link, Navbar } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { AutoRefreshTimeout, makeStatusLine, statusType } from 'src/components/submission-common'
+import { AutoRefreshInterval, makeStatusLine, statusType } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import * as Nav from 'src/libs/nav'
@@ -45,7 +45,7 @@ export const SubmissionHistory = () => {
 
       // only refresh if there are Run Sets in non-terminal state
       if (_.some(({ state }) => !isRunSetInTerminalState(state), mergedRunSets)) {
-        scheduledRefresh.current = setTimeout(refresh, AutoRefreshTimeout)
+        scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
       }
     } catch (error) {
       notify('error', 'Error loading previous run sets', { detail: await (error instanceof Response ? error.text() : error) })


### PR DESCRIPTION
Tested locally:
Below screenshot (from Submission Details) shows that auto refreshing happens as long as there is a run in non-terminal state. Once all runs reach terminal state the auto refreshing stops. Same logic applies to Submission History page. 
Note: I had updated the timeout to be 1 second for testing purposes as workflows usually fail within 1 minute. console.log statements have also been removed
![Screen Shot 2023-01-24 at 5 04 26 PM](https://user-images.githubusercontent.com/16748522/214439097-b86bf184-e3d4-46a5-ac44-c50402627702.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1653