### PR TITLE
[WM-1659] Display warning icon if attribute is missing for required input

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -225,10 +225,9 @@ export const inputsTable = props => {
   const inputSourceTypes = _.invert(inputSourceLabels)
 
   const recordLookupSelect = rowIndex => {
-    // console.log(`***** Orange icon for input ${_.get(`${rowIndex}.input_name`, configuredInputDefinition)}? ${missingRequiredInputs.includes(_.get(`${rowIndex}.input_name`, configuredInputDefinition))}`)
     const currentInputName = _.get(`${rowIndex}.input_name`, configuredInputDefinition)
 
-    return div({ style: { display: 'flex', alignItems: 'center', width: '100%', paddingTop: '0.5rem', paddingBottom: '0.5rem' }}, [
+    return div({ style: { display: 'flex', alignItems: 'center', width: '100%', paddingTop: '0.5rem', paddingBottom: '0.5rem' } }, [
       h(Select, {
         isDisabled: false,
         'aria-label': 'Select an Attribute',

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -8,6 +8,7 @@ import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { FlexTable, GridTable, HeaderCell, Resizable, Sortable, TextCell } from 'src/components/table'
+import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
@@ -210,6 +211,7 @@ export const inputsTable = props => {
   const {
     configuredInputDefinition, setConfiguredInputDefinition,
     inputTableSort, setInputTableSort,
+    missingRequiredInputs,
     selectedDataTable
   } = props
 
@@ -223,27 +225,37 @@ export const inputsTable = props => {
   const inputSourceTypes = _.invert(inputSourceLabels)
 
   const recordLookupSelect = rowIndex => {
-    return h(Select, {
-      isDisabled: false,
-      'aria-label': 'Select an Attribute',
-      isClearable: false,
-      value: _.get(`${rowIndex}.source.record_attribute`, configuredInputDefinition),
-      onChange: ({ value }) => {
-        const newAttribute = _.get(`${value}.name`, dataTableAttributes)
-        const newSource = {
-          type: _.get(`${rowIndex}.source.type`, configuredInputDefinition),
-          record_attribute: newAttribute
-        }
-        const newConfig = _.set(`${rowIndex}.source`, newSource, configuredInputDefinition)
-        setConfiguredInputDefinition(newConfig)
-      },
-      placeholder: 'Select Attribute',
-      options: _.keys(dataTableAttributes),
-      // ** https://stackoverflow.com/questions/55830799/how-to-change-zindex-in-react-select-drowpdown
-      styles: { container: old => ({ ...old, display: 'inline-block', width: '100%' }), menuPortal: base => ({ ...base, zIndex: 9999 }) },
-      menuPortalTarget: document.body,
-      menuPlacement: 'top'
-    })
+    // console.log(`***** Orange icon for input ${_.get(`${rowIndex}.input_name`, configuredInputDefinition)}? ${missingRequiredInputs.includes(_.get(`${rowIndex}.input_name`, configuredInputDefinition))}`)
+    const currentInputName = _.get(`${rowIndex}.input_name`, configuredInputDefinition)
+
+    return div({ style: { display: 'flex', alignItems: 'center', width: '100%', paddingTop: '0.5rem', paddingBottom: '0.5rem' }}, [
+      h(Select, {
+        isDisabled: false,
+        'aria-label': 'Select an Attribute',
+        isClearable: false,
+        value: _.get(`${rowIndex}.source.record_attribute`, configuredInputDefinition),
+        onChange: ({ value }) => {
+          const newAttribute = _.get(`${value}.name`, dataTableAttributes)
+          const newSource = {
+            type: _.get(`${rowIndex}.source.type`, configuredInputDefinition),
+            record_attribute: newAttribute
+          }
+          const newConfig = _.set(`${rowIndex}.source`, newSource, configuredInputDefinition)
+          setConfiguredInputDefinition(newConfig)
+        },
+        placeholder: 'Select Attribute',
+        options: _.keys(dataTableAttributes),
+        // ** https://stackoverflow.com/questions/55830799/how-to-change-zindex-in-react-select-drowpdown
+        styles: { container: old => ({ ...old, display: 'inline-block', width: '100%' }), menuPortal: base => ({ ...base, zIndex: 9999 }) },
+        menuPortalTarget: document.body,
+        menuPlacement: 'top'
+      }),
+      missingRequiredInputs.includes(currentInputName) && h(TooltipTrigger, { content: 'This attribute is required' }, [
+        icon('error-standard', {
+          size: 14, style: { marginLeft: '0.5rem', color: colors.warning(), cursor: 'help' }
+        })
+      ])
+    ])
   }
 
   const parameterValueSelect = rowIndex => {

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -209,10 +209,10 @@ const parseMethodString = methodString => {
 
 export const inputsTable = props => {
   const {
+    selectedDataTable,
     configuredInputDefinition, setConfiguredInputDefinition,
     inputTableSort, setInputTableSort,
-    missingRequiredInputs,
-    selectedDataTable
+    missingRequiredInputs
   } = props
 
   const dataTableAttributes = _.keyBy('name', selectedDataTable.attributes)


### PR DESCRIPTION
Tested changes locally:
If any **required** input has a missing attribute a warning icon appears next to it in table. Inputs tab itself also has warning icon next to it and Submit button is disabled. Once user selects attributes for such inputs, the icons disappear and when all errors have been resolved icon next to Input tab also disappears and Submit button is enabled.

`assemble_refbased` workflow has 2 required inputs that are missing attributes:
<img src="https://user-images.githubusercontent.com/16748522/215221396-ae0e1d52-7c57-4991-a32e-1d396321b38c.png" width="1000" height="400" />

Selecting attribute for 1 required input makes warning icon next to it disappear. Input tab has warning icon next to it.
<img src="https://user-images.githubusercontent.com/16748522/215221470-3aaaef13-d3d9-4d86-bf97-5403363087a5.png" width="1000" height="400" />

All required inputs have attributes and warning icon next to Inputs tab disappears. Submit is enabled (since I have also selected data row).
<img src="https://user-images.githubusercontent.com/16748522/215221647-7d9671e0-4246-4847-9ad5-061658f6b67e.png" width="1000" height="400" />

Tooltip for warning icon:
![Screen Shot 2023-01-27 at 5 58 15 PM](https://user-images.githubusercontent.com/16748522/215221788-8326c785-947c-4e68-882a-1bd2305c03f0.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1659