### PR TITLE
WM-1668: Fix type names and italicize optionals

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -303,7 +303,7 @@ export const inputsTable = props => {
           size: { basis: 160, grow: 0 },
           headerRenderer: () => h(HeaderCell, ['Type']),
           cellRenderer: ({ rowIndex }) => {
-            return h(TextCell, {}, [Utils.renderTypeText(configuredInputDefinition[rowIndex].input_type)])
+            return h(TextCell, { style: Utils.typeStyle(configuredInputDefinition[rowIndex].input_type) }, [Utils.renderTypeText(configuredInputDefinition[rowIndex].input_type)])
           }
         },
         {

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -296,7 +296,7 @@ export const inputsTable = props => {
           field: 'workflowVariable',
           headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'workflowVariable', onSort: setInputTableSort }, [h(HeaderCell, ['Variable'])]),
           cellRenderer: ({ rowIndex }) => {
-            return h(TextCell, {}, [parseMethodString(configuredInputDefinition[rowIndex].input_name).variable])
+            return h(TextCell, { style: Utils.typeStyle(configuredInputDefinition[rowIndex].input_type) }, [parseMethodString(configuredInputDefinition[rowIndex].input_name).variable])
           }
         },
         {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -161,12 +161,20 @@ export const convertValue = _.curry((type, value) => {
   }
 })
 
+export const typeStyle = iotype => {
+  if (_.get('type', iotype) === 'optional') {
+    return { 'font-style': 'italic' }
+  } else {
+    return {}
+  }
+}
+
 export const renderTypeText = iotype => {
   if (_.has('primitive_type', iotype)) {
     return iotype.primitive_type
   }
   if (_.has('optional_type', iotype)) {
-    return `${_.get('optional_type.primitive_type', iotype)} (optional)`
+    return `${renderTypeText(_.get('optional_type', iotype))}?`
   }
   if (_.has('array_type', iotype)) {
     return `Array[${renderTypeText(_.get('array_type', iotype))}]`

--- a/src/libs/utils.test.js
+++ b/src/libs/utils.test.js
@@ -14,9 +14,10 @@ describe('makeCompleteDate', () => {
 describe('submission-common tests', () => {
   it('variable type text is rendered properly', () => {
     expect(renderTypeText({ type: 'primitive', primitive_type: 'File' })).toStrictEqual('File')
-    expect(renderTypeText({ type: 'optional', optional_type: { type: 'primitive', primitive_type: 'String' } })).toStrictEqual('String (optional)')
+    expect(renderTypeText({ type: 'optional', optional_type: { type: 'primitive', primitive_type: 'String' } })).toStrictEqual('String?')
     expect(renderTypeText({ type: 'array', array_type: { type: 'primitive', primitive_type: 'Int' } })).toStrictEqual('Array[Int]')
-    expect(renderTypeText({ type: 'array', array_type: { type: 'optional', optional_type: { type: 'primitive', primitive_type: 'Int' } } })).toStrictEqual('Array[Int (optional)]')
+    expect(renderTypeText({ type: 'array', array_type: { type: 'optional', optional_type: { type: 'primitive', primitive_type: 'Int' } } })).toStrictEqual('Array[Int?]')
+    expect(renderTypeText({ type: 'optional', optional_type: { type: 'array', array_type: { type: 'optional', optional_type: { type: 'primitive', primitive_type: 'Int' } } } })).toStrictEqual('Array[Int?]?')
     expect(renderTypeText({ type: 'array', array_type: { type: 'array', array_type: { type: 'array', array_type: { type: 'primitive', primitive_type: 'Int' } } } })).toStrictEqual('Array[Array[Array[Int]]]')
     expect(renderTypeText({ type: 'struct', struct_type: 'File' })).toStrictEqual('Unsupported Type')
     expect(renderTypeText({ type: 'map', map_type: 'File' })).toStrictEqual('Unsupported Type')


### PR DESCRIPTION
Fixes arrays to no longer assume that the inner values must be primitives.

Stowaway changes which seemed useful to add in and took not much extra time:
- Updating optional type names from `String (optional)` to `String?`, to match how WDL displays them.
- Updating optional input font to italic on the input name and type, just like in Terra UI

Examples, including showing the table_map input now rendering correctly:
![image](https://user-images.githubusercontent.com/13006282/215587487-614b47af-47a6-4d67-82e1-eed1b5a50acf.png)

![image](https://user-images.githubusercontent.com/13006282/215587301-033c7fbe-b24b-41be-aed8-119436e78184.png)
