### PR TITLE
[WM-1664] Table in Select data tab has resizable columns

### DIFF
--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { a, div, h, h2, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { icon } from 'src/components/icons'
@@ -24,6 +24,7 @@ export const SubmissionConfig = ({ methodId }) => {
   const [availableMethodVersions, setAvailableMethodVersions] = useState()
   const [selectedMethodVersion, setSelectedMethodVersion] = useState()
   const [records, setRecords] = useState([])
+  const [dataTableColumnWidths, setDataTableColumnWidths] = useState({})
 
   // Options chosen on this page:
   const [selectedRecordType, setSelectedRecordType] = useState()
@@ -44,8 +45,9 @@ export const SubmissionConfig = ({ methodId }) => {
   const [launching, setLaunching] = useState(undefined)
   const [noRecordTypeData, setNoRecordTypeData] = useState(null)
 
-
+  const dataTableRef = useRef()
   const signal = useCancellation()
+
   const loadRecordsData = async recordType => {
     try {
       const searchResult = await Ajax(signal).Wds.search.post(recordType)
@@ -120,6 +122,10 @@ export const SubmissionConfig = ({ methodId }) => {
 
     validateInputs()
   }, [records, recordTypes, configuredInputDefinition])
+
+  useEffect(() => {
+    dataTableRef.current?.recomputeColumnSizes()
+  }, [dataTableColumnWidths, records, recordTypes])
 
   const renderSummary = () => {
     return div({ style: { margin: '4em' } }, [
@@ -229,6 +235,8 @@ export const SubmissionConfig = ({ methodId }) => {
 
   const renderRecordSelector = () => {
     return recordTypes && records.length ? h(recordsTable, {
+      dataTableColumnWidths, setDataTableColumnWidths,
+      dataTableRef,
       records,
       selectedRecords, setSelectedRecords,
       selectedDataTable: _.keyBy('name', recordTypes)[selectedRecordType || records[0].type],

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -400,6 +400,111 @@ describe('SubmissionConfig records selector', () => {
     expect(rowsFOO.length).toBe(5)
   })
 
+  it('should resize the columns and new widths should be preserved when data table selection changes within given workflow', async () => {
+    // ** ARRANGE **
+    const mockRunSetResponse = jest.fn(() => Promise.resolve(runSetResponse))
+    const mockMethodsResponse = jest.fn(() => Promise.resolve(methodsResponse))
+    const mockSearchResponse = jest.fn(recordType => Promise.resolve(searchResponses[recordType]))
+    const mockTypesResponse = jest.fn(() => Promise.resolve(typesResponse))
+
+    await Ajax.mockImplementation(() => {
+      return {
+        Cbas: {
+          runSets: {
+            getForMethod: mockRunSetResponse
+          },
+          methods: {
+            getById: mockMethodsResponse
+          }
+        },
+        Wds: {
+          search: {
+            post: mockSearchResponse
+          },
+          types: {
+            get: mockTypesResponse
+          }
+        }
+      }
+    })
+
+    // ** ACT **
+    render(h(SubmissionConfig))
+
+    // ** ASSERT **
+    await waitFor(() => {
+      expect(mockRunSetResponse).toHaveBeenCalledTimes(1)
+      expect(mockTypesResponse).toHaveBeenCalledTimes(1)
+      expect(mockMethodsResponse).toHaveBeenCalledTimes(0)
+      expect(mockSearchResponse).toHaveBeenCalledTimes(0)
+    })
+    const table = await screen.findByRole('table')
+    // after the initial render (not before), records data should have been retrieved once
+    await waitFor(() => {
+      expect(mockSearchResponse).toHaveBeenCalledTimes(1)
+      expect(mockMethodsResponse).toHaveBeenCalledTimes(1)
+    })
+
+    const fooRows1 = within(table).queryAllByRole('row')
+    expect(fooRows1.length).toBe(5)
+
+    const fooHeaders1 = within(fooRows1[0]).queryAllByRole('columnheader')
+    expect(fooHeaders1.length).toBe(4)
+    within(fooHeaders1[1]).getByText('ID')
+    expect(getComputedStyle(fooHeaders1[1]).width).toBe('300px') // initial column width
+
+    // ** ACT **
+    // simulate user resizing the column 'ID' for data table 'FOO'
+    const fooDraggableIcon = fooHeaders1[1].querySelector("[data-icon='columnGrabber']")
+    fireEvent.mouseDown(fooDraggableIcon)
+    fireEvent.mouseMove(fooDraggableIcon, { clientX: 200, clientY: 0 }) // user moves the icon 200px to right
+    fireEvent.mouseUp(fooDraggableIcon)
+
+    // ** ASSERT **
+    // new width of column 'ID' for data table 'FOO' should be 500
+    expect(getComputedStyle(fooHeaders1[1]).width).toBe('500px')
+
+    // ** ACT **
+    // Change Data Table to 'BAR'
+    const dropdown1 = await screen.findByLabelText('Select a data table')
+    await act(async () => {
+      await selectEvent.select(dropdown1, ['BAR'])
+    })
+
+    // ** ASSERT **
+    const barRows = within(table).queryAllByRole('row')
+    expect(barRows.length).toBe(3)
+    const barHeaders = within(barRows[0]).queryAllByRole('columnheader')
+    expect(barHeaders.length).toBe(4)
+    within(barHeaders[1]).getByText('ID')
+    // even though both 'FOO' and 'BAR' data tables have 'ID' columns their widths can be different
+    expect(getComputedStyle(barHeaders[1]).width).toBe('300px') // initial column width
+
+    // ** ACT **
+    // simulate user resizing the column 'ID' for data table 'BAR'
+    const barDraggableIcon = barHeaders[1].querySelector("[data-icon='columnGrabber']")
+    fireEvent.mouseDown(barDraggableIcon)
+    fireEvent.mouseMove(barDraggableIcon, { clientX: 50, clientY: 0 }) // user moves the icon 50px to right
+    fireEvent.mouseUp(barDraggableIcon)
+
+    // ** ASSERT **
+    // new width of column 'ID' for data table 'BAR' should be 350
+    expect(getComputedStyle(barHeaders[1]).width).toBe('350px')
+
+    // ** ACT **
+    // Change Data Table back to 'FOO'
+    const dropdown2 = await screen.findByLabelText('Select a data table')
+    await act(async () => {
+      await selectEvent.select(dropdown2, ['FOO'])
+    })
+
+    // ** ASSERT **
+    // verify that the width of column 'ID' has been preserved from previous resizing
+    const fooRows2 = within(table).queryAllByRole('row')
+    const fooHeaders2 = within(fooRows2[0]).queryAllByRole('columnheader')
+    expect(getComputedStyle(fooHeaders2[1]).width).toBe('500px')
+  })
+
   it('when records are selected, should display modal when Submit button is clicked', async () => {
     const mockRunSetResponse = jest.fn(() => Promise.resolve(runSetResponse))
     const mockMethodsResponse = jest.fn(() => Promise.resolve(methodsResponse))


### PR DESCRIPTION
Data table columns are now resizable. The resized column widths are persisted within the Submission Config page for a workflow. If user navigates back to Select Workflow page and selects the previous workflow again the column widths will be reset to default. This has been purposefully kept simple for the first iteration and we can iterate on it based on user feedback.

Note: If 2 data samples have same columns, the user can resize same named columns to different widths and they will be persisted. So a column with same name across different data samples can have different column widths.

Before: Columns at default width
<img src="https://user-images.githubusercontent.com/16748522/215790721-ace615c4-b66d-4f88-a7cb-08b5546f362d.png" width="1000" height="700" />

Resizing each columns to different width. The log messages (now removed) show how the widths are stored
<img src="https://user-images.githubusercontent.com/16748522/215790977-94d22553-9920-4981-af06-60c23442a8f5.png" width="1000" height="700" />


Closes https://broadworkbench.atlassian.net/browse/WM-1664