### PR TITLE
[WM-1667] Don't submit parameter_value when input source is changed to None

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -330,7 +330,7 @@ export const inputsTable = props => {
                   const param = newType === 'record_lookup' ? 'record_attribute' : 'parameter_value'
                   newSource = {
                     type: newType,
-                    [param]: _.get(`${rowIndex}.source.${param}`, configuredInputDefinition)
+                    [param]: ''
                   }
                 }
                 const newConfig = _.set(`${rowIndex}.source`, newSource, configuredInputDefinition)

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -321,10 +321,17 @@ export const inputsTable = props => {
               value: _.get(_.get(`${rowIndex}.source.type`, configuredInputDefinition), inputSourceLabels) || null,
               onChange: ({ value }) => {
                 const newType = _.get(value, inputSourceTypes)
-                const param = newType === 'record_lookup' ? 'record_attribute' : 'parameter_value'
-                const newSource = {
-                  type: newType,
-                  [param]: _.get(`${rowIndex}.source.${param}`, configuredInputDefinition)
+                let newSource
+                if (newType === 'none') {
+                  newSource = {
+                    type: newType
+                  }
+                } else {
+                  const param = newType === 'record_lookup' ? 'record_attribute' : 'parameter_value'
+                  newSource = {
+                    type: newType,
+                    [param]: _.get(`${rowIndex}.source.${param}`, configuredInputDefinition)
+                  }
                 }
                 const newConfig = _.set(`${rowIndex}.source`, newSource, configuredInputDefinition)
                 setConfiguredInputDefinition(newConfig)

--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -42,7 +42,7 @@ export const SubmissionConfig = ({ methodId }) => {
   const [inputTableSort, setInputTableSort] = useState({ field: 'taskVariable', direction: 'asc' })
   const [outputTableSort, setOutputTableSort] = useState({ field: 'taskVariable', direction: 'asc' })
 
-  const [launching, setLaunching] = useState(undefined)
+  const [displayLaunchModal, setDisplayLaunchModal] = useState(false)
   const [noRecordTypeData, setNoRecordTypeData] = useState(null)
 
   const dataTableRef = useRef()
@@ -190,18 +190,19 @@ export const SubmissionConfig = ({ methodId }) => {
           tooltip: _.isEmpty(selectedRecords) ? 'No records selected' : '',
           onClick: () => {
             updateRunSetName()
-            setLaunching(true)
+            setDisplayLaunchModal(true)
           }
         }, ['Submit'])
       }),
-      (launching !== undefined) && h(Modal, {
+      displayLaunchModal && h(Modal, {
         title: 'Send submission',
         width: 600,
-        onDismiss: () => setLaunching(undefined),
+        onDismiss: () => setDisplayLaunchModal(false),
         showCancel: true,
         okButton:
           h(ButtonPrimary, {
             disabled: false,
+            'aria-label': 'Launch Submission',
             onClick: () => submitRun()
           }, ['Submit'])
       }, [
@@ -282,6 +283,7 @@ export const SubmissionConfig = ({ methodId }) => {
         }
       }
 
+      setDisplayLaunchModal(false)
       const runSetObject = await Ajax(signal).Cbas.runSets.post(runSetsPayload)
       notify('success', 'Workflow successfully submitted', { message: 'You may check on the progress of workflow on this page anytime.', timeout: 5000 })
       Nav.goToPath('submission-details', {

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -697,7 +697,7 @@ describe('SubmissionConfig inputs/outputs definitions', () => {
     expect(thirdInputRow.length).toBe(5)
     expect(thirdInputRow[0].textContent).toBe('target_workflow_1')
     within(thirdInputRow[1]).getByText('optional_var')
-    within(thirdInputRow[2]).getByText('String (optional)')
+    within(thirdInputRow[2]).getByText('String?')
     within(thirdInputRow[3]).getByText('Type a Value')
     within(thirdInputRow[4]).getByDisplayValue('Hello World')
   })


### PR DESCRIPTION
This PR fixes the behavior mentioned in the ticket. 
Before: The payload being sent for input switched to "None" source included `parameter_value`
```
{
  "input_name": "fetch_sra_to_bam.Fetch_SRA_to_BAM.docker",
  "input_type": {
    "type": "optional",
    "optional_type": {
      "type": "primitive",
      "primitive_type": "String"
    }
  },
  "source": {
    "type": "none",
    "parameter_value": "quay.io/broadinstitute/ncbi-tools:2.10.7.10"
  }
}
```

Now
```
{
    "input_name": "fetch_sra_to_bam.Fetch_SRA_to_BAM.docker",
    "input_type": {
      "type": "optional",
      "optional_type": {
        "type": "primitive",
        "primitive_type": "String"
      }
    },
    "source": {
      "type": "none"
    }
}
```

Closes https://broadworkbench.atlassian.net/browse/WM-1667