### PR TITLE
[WM-1721] Change banner title to "Run Workflows with Cromwell"

### DIFF
--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -303,7 +303,7 @@ export const SubmissionConfig = ({ methodId }) => {
         position: 'relative'
       }
     }, [
-      Navbar('SUBMIT WORKFLOWS WITH CROMWELL'),
+      Navbar('RUN WORKFLOWS WITH CROMWELL'),
       renderSummary()
     ]),
     div({

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -166,7 +166,7 @@ export const SubmissionDetails = ({ submissionId }) => {
   const rowWidth = 100
   const rowHeight = 50
   return div({ id: 'submission-details-page' }, [
-    Navbar('SUBMIT WORKFLOWS WITH CROMWELL'),
+    Navbar('RUN WORKFLOWS WITH CROMWELL'),
     div({
       style: {
         borderBottom: '2px solid rgb(116, 174, 67)',

--- a/src/pages/SubmissionHistory/SubmissionHistory.js
+++ b/src/pages/SubmissionHistory/SubmissionHistory.js
@@ -93,7 +93,7 @@ export const SubmissionHistory = () => {
   const rowHeight = 250
 
   return h(Fragment, [
-    Navbar(),
+    Navbar('RUN WORKFLOWS WITH CROMWELL'),
     div({ style: { margin: '4em' } }, [
       div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'space-between' } }, [
         h2(['Submission History']),

--- a/src/pages/SubmitWorkflow.js
+++ b/src/pages/SubmitWorkflow.js
@@ -48,7 +48,7 @@ export const SubmitWorkflow = () => {
   })
 
   return div([
-    Navbar(),
+    Navbar('RUN WORKFLOWS WITH CROMWELL'),
     div({ style: { margin: '4rem' } }, [
       div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'space-between' } }, [
         h2(['Submit a workflow']),


### PR DESCRIPTION
Based on the [conversation with Sara on Slack](https://broadinstitute.slack.com/archives/G01CVT4GJ8H/p1676579460275039), it was decided to rename the title to `Run workflows...` instead of `Submit workflows...` and keep it consistent across all pages. The landing page banner has also been added:
![Screen Shot 2023-02-16 at 5 14 46 PM](https://user-images.githubusercontent.com/16748522/219499232-dcc592d2-194c-4882-97e4-79771524813a.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1721