### PR TITLE
WM-1729: Better tooltip for missing attribute

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -236,7 +236,7 @@ export const inputsTable = props => {
     selectedDataTable,
     configuredInputDefinition, setConfiguredInputDefinition,
     inputTableSort, setInputTableSort,
-    missingRequiredInputs
+    missingRequiredInputs, missingExpectedAttributes
   } = props
 
   const dataTableAttributes = _.keyBy('name', selectedDataTable.attributes)
@@ -266,7 +266,7 @@ export const inputsTable = props => {
           const newConfig = _.set(`${inputTableData[rowIndex].configurationIndex}.source`, newSource, configuredInputDefinition)
           setConfiguredInputDefinition(newConfig)
         },
-        placeholder: 'Select Attribute',
+        placeholder: _.get(`${rowIndex}.source.record_attribute`, inputTableData) || 'Select Attribute',
         options: _.keys(dataTableAttributes),
         // ** https://stackoverflow.com/questions/55830799/how-to-change-zindex-in-react-select-drowpdown
         styles: { container: old => ({ ...old, display: 'inline-block', width: '100%' }), menuPortal: base => ({ ...base, zIndex: 9999 }) },
@@ -274,6 +274,11 @@ export const inputsTable = props => {
         menuPlacement: 'top'
       }),
       missingRequiredInputs.includes(currentInputName) && h(TooltipTrigger, { content: 'This attribute is required' }, [
+        icon('error-standard', {
+          size: 14, style: { marginLeft: '0.5rem', color: colors.warning(), cursor: 'help' }
+        })
+      ]),
+      missingExpectedAttributes.includes(currentInputName) && h(TooltipTrigger, { content: 'This attribute doesn\'t exist in data table' }, [
         icon('error-standard', {
           size: 14, style: { marginLeft: '0.5rem', color: colors.warning(), cursor: 'help' }
         })

--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -35,7 +35,7 @@ export const SubmissionConfig = ({ methodId }) => {
   const [configuredInputDefinition, setConfiguredInputDefinition] = useState()
   const [configuredOutputDefinition, setConfiguredOutputDefinition] = useState()
   const [missingRequiredInputs, setMissingRequiredInputs] = useState([])
-  const [missingExpectedAttribute, setMissingExpectedAttributes] = useState([])
+  const [missingExpectedAttributes, setMissingExpectedAttributes] = useState([])
   const [viewWorkflowScriptModal, setViewWorkflowScriptModal] = useState(false)
 
   // TODO: These should probably be moved to the modal:
@@ -215,7 +215,7 @@ export const SubmissionConfig = ({ methodId }) => {
       h(StepButtons, {
         tabs: [
           { key: 'select-data', title: 'Select Data', isValid: true },
-          { key: 'inputs', title: 'Inputs', isValid: !missingRequiredInputs.length && !missingExpectedAttribute.length },
+          { key: 'inputs', title: 'Inputs', isValid: !missingRequiredInputs.length && !missingExpectedAttributes.length },
           { key: 'outputs', title: 'Outputs', isValid: true }
         ],
         activeTab: activeTab.key || 'select-data',
@@ -223,7 +223,7 @@ export const SubmissionConfig = ({ methodId }) => {
         finalStep: h(ButtonPrimary, {
           'aria-label': 'Submit button',
           style: { marginLeft: '1rem' },
-          disabled: _.isEmpty(selectedRecords) || missingRequiredInputs.length || missingExpectedAttribute.length,
+          disabled: _.isEmpty(selectedRecords) || missingRequiredInputs.length || missingExpectedAttributes.length,
           tooltip: _.isEmpty(selectedRecords) ? 'No records selected' : '',
           onClick: () => {
             updateRunSetName()
@@ -288,7 +288,7 @@ export const SubmissionConfig = ({ methodId }) => {
       selectedDataTable: _.keyBy('name', recordTypes)[selectedRecordType],
       configuredInputDefinition, setConfiguredInputDefinition,
       inputTableSort, setInputTableSort,
-      missingRequiredInputs, missingExpectedAttribute
+      missingRequiredInputs, missingExpectedAttributes
     }) : 'No data table rows available or input definition is not configured...'
   }
 

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -1040,13 +1040,14 @@ describe('SubmissionConfig inputs/outputs definitions', () => {
     within(cellsFoo[2]).getByText('Int')
     within(cellsFoo[3]).getByText('Fetch from Data Table')
     // input configuration expects attribute 'foo_rating' to be present, but it isn't available in the data table.
-    // Hence, the select box will be empty and defaulted to 'Select Attribute' and orange warning icon will be present next to it
-    within(cellsFoo[4]).getByText('Select Attribute')
+    // Hence, the select box will be empty and defaulted to the attribute name as its placeholder,
+    // but there will be an orange warning icon will be present next to it
+    within(cellsFoo[4]).getByText('foo_rating')
     within(cellsFoo[4]).queryByRole('img', { 'data-icon': 'error-standard' })
 
     // ** ACT **
     // user selects the attribute 'rating_for_foo' for input 'foo_rating_workflow_var'
-    await userEvent.click(within(cellsFoo[4]).getByText('Select Attribute'))
+    await userEvent.click(within(cellsFoo[4]).getByText('foo_rating'))
     const selectOption = await screen.findByText(`rating_for_foo`)
     await userEvent.click(selectOption)
 


### PR DESCRIPTION
This is now the outcome when a preloaded workflow is missing a data table value:

![image](https://user-images.githubusercontent.com/13006282/221045871-9655c16e-b3a5-46cb-81b3-79d08f304638.png)
