### PR TITLE
[WM-1755] Fix auto-refresh on Submission Details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composite-batch-analysis-service-ui",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -7,12 +7,14 @@ import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import { FlexTable, GridTable, HeaderCell, Resizable, Sortable, TextCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
+import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { differenceFromDatesInSeconds, differenceFromNowInSeconds } from 'src/libs/utils'
+import { notify } from 'src/libs/notifications'
 import * as Utils from 'src/libs/utils'
+import { differenceFromDatesInSeconds, differenceFromNowInSeconds } from 'src/libs/utils'
 
 
-export const AutoRefreshInterval = 1000 * 60 // 1 minute
+export const AutoRefreshInterval = 1000 * 15 // 1 minute
 
 const iconSize = 24
 export const addCountSuffix = (label, count = undefined) => {
@@ -87,6 +89,26 @@ export const getDuration = (state, submissionDate, lastModifiedTimestamp, stateC
   return stateCheckCallback(state) ?
     differenceFromDatesInSeconds(submissionDate, lastModifiedTimestamp) :
     differenceFromNowInSeconds(submissionDate)
+}
+
+export const loadRunSetData = async signal => {
+  try {
+    const getRunSets = await Ajax(signal).Cbas.runSets.get()
+    const allRunSets = getRunSets.run_sets
+    return _.map(r => _.merge(r, { duration: getDuration(r.state, r.submission_timestamp, r.last_modified_timestamp, isRunSetInTerminalState) }),
+      allRunSets)
+  } catch (error) {
+    notify('error', 'Error getting run set data', { detail: await (error instanceof Response ? error.text() : error) })
+  }
+}
+
+export const loadRunData = async (signal, submissionId) => {
+  try {
+    const runsResponse = await Ajax(signal).Cbas.runs.get(submissionId)
+    return runsResponse?.runs
+  } catch (error) {
+    notify('error', 'Error getting run set data', { detail: await (error instanceof Response ? error.text() : error) })
+  }
 }
 
 export const recordsTable = props => {

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -102,15 +102,6 @@ export const loadRunSetData = async signal => {
   }
 }
 
-export const loadRunsData = async (signal, submissionId) => {
-  try {
-    const runsResponse = await Ajax(signal).Cbas.runs.get(submissionId)
-    return runsResponse?.runs
-  } catch (error) {
-    notify('error', 'Error getting run set data', { detail: await (error instanceof Response ? error.text() : error) })
-  }
-}
-
 export const recordsTable = props => {
   const {
     dataTableColumnWidths, setDataTableColumnWidths,

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -14,7 +14,7 @@ import * as Utils from 'src/libs/utils'
 import { differenceFromDatesInSeconds, differenceFromNowInSeconds } from 'src/libs/utils'
 
 
-export const AutoRefreshInterval = 1000 * 15 // 1 minute
+export const AutoRefreshInterval = 1000 * 60 // 1 minute
 
 const iconSize = 24
 export const addCountSuffix = (label, count = undefined) => {
@@ -102,7 +102,7 @@ export const loadRunSetData = async signal => {
   }
 }
 
-export const loadRunData = async (signal, submissionId) => {
+export const loadRunsData = async (signal, submissionId) => {
   try {
     const runsResponse = await Ajax(signal).Cbas.runs.get(submissionId)
     return runsResponse?.runs

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -6,7 +6,7 @@ import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
-import { AutoRefreshInterval, getDuration, isRunInTerminalState, isRunSetInTerminalState, makeStatusLine, loadRunSetData } from 'src/components/submission-common'
+import { AutoRefreshInterval, getDuration, isRunInTerminalState, isRunSetInTerminalState, loadRunSetData, makeStatusLine } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -97,8 +97,6 @@ export const SubmissionDetails = ({ submissionId }) => {
   })
 
   useOnMount(async () => {
-    await loadRunSetData(signal)
-
     const loadMethodsData = async methodVersionId => {
       try {
         const methodsResponse = await Ajax(signal).Cbas.methods.getByMethodVersionId(methodVersionId)
@@ -110,7 +108,7 @@ export const SubmissionDetails = ({ submissionId }) => {
     }
 
     await refresh()
-    loadRunSetData().then(runSet => runSet && loadMethodsData(runSet.method_version_id))
+    loadRunSetData(signal).then(runSet => runSet && loadMethodsData(runSet.method_version_id))
 
     return () => {
       if (scheduledRefresh.current) {

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -86,10 +86,7 @@ export const SubmissionDetails = ({ submissionId }) => {
 
       // only refresh if there are Run Sets/Runs in non-terminal state
       if (_.some(({ state }) => !isRunSetInTerminalState(state), loadedRunSetData)) {
-        // Nesting these checks to avoid a "double refresh"
-        if (_.some(({ state }) => !isRunInTerminalState(state), runsAnnotatedWithDurations)) {
-          scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
-        }
+        scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
       }
     } catch (error) {
       notify('error', 'Error loading previous runs', { detail: await (error instanceof Response ? error.text() : error) })

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -6,7 +6,7 @@ import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
-import { AutoRefreshInterval, getDuration, isRunInTerminalState, isRunSetInTerminalState, makeStatusLine, loadRunSetData, loadRunData } from 'src/components/submission-common'
+import { AutoRefreshInterval, getDuration, isRunInTerminalState, isRunSetInTerminalState, makeStatusLine, loadRunSetData, loadRunsData } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -79,7 +79,7 @@ export const SubmissionDetails = ({ submissionId }) => {
       const loadedRunSetData = await loadRunSetData(signal)
       setRunSetData(loadedRunSetData)
 
-      const loadedRuns = await loadRunData(signal, submissionId)
+      const loadedRuns = await loadRunsData(signal, submissionId)
       setRunsData(loadedRuns)
 
       // only refresh if there are Run Sets/Runs in non-terminal state

--- a/src/pages/SubmissionDetails.js
+++ b/src/pages/SubmissionDetails.js
@@ -84,7 +84,7 @@ export const SubmissionDetails = ({ submissionId }) => {
       const loadedRunSetData = await loadRunSetData(signal)
       setRunSetData(loadedRunSetData)
 
-      // only refresh if there are Run Sets/Runs in non-terminal state
+      // only refresh if there are run sets in non-terminal state
       if (_.some(({ state }) => !isRunSetInTerminalState(state), loadedRunSetData)) {
         scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
       }

--- a/src/pages/SubmissionDetails.test.js
+++ b/src/pages/SubmissionDetails.test.js
@@ -151,7 +151,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(3)
+      expect(getRunsSets).toHaveBeenCalledTimes(2)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -214,7 +214,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(3)
+      expect(getRunsSets).toHaveBeenCalledTimes(2)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -319,7 +319,7 @@ describe('Submission Details page', () => {
     render(h(SubmissionDetails, { submissionId }))
 
     await waitFor(() => {
-      expect(getRunsSets).toHaveBeenCalledTimes(3)
+      expect(getRunsSets).toHaveBeenCalledTimes(2)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -366,7 +366,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(3)
+      expect(getRunsSets).toHaveBeenCalledTimes(2)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 

--- a/src/pages/SubmissionDetails.test.js
+++ b/src/pages/SubmissionDetails.test.js
@@ -151,7 +151,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(1)
+      expect(getRunsSets).toHaveBeenCalledTimes(3)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -214,7 +214,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(1)
+      expect(getRunsSets).toHaveBeenCalledTimes(3)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -295,7 +295,7 @@ describe('Submission Details page', () => {
     render(h(SubmissionDetails, { submissionId }))
 
     await waitFor(() => {
-      expect(getRunsSets).toHaveBeenCalledTimes(1)
+      expect(getRunsSets).toHaveBeenCalledTimes(3)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 
@@ -342,7 +342,7 @@ describe('Submission Details page', () => {
 
     await waitFor(() => {
       expect(getRuns).toHaveBeenCalledTimes(1)
-      expect(getRunsSets).toHaveBeenCalledTimes(1)
+      expect(getRunsSets).toHaveBeenCalledTimes(3)
       expect(getMethods).toHaveBeenCalledTimes(1)
     })
 

--- a/src/pages/SubmissionHistory/SubmissionHistory.js
+++ b/src/pages/SubmissionHistory/SubmissionHistory.js
@@ -4,9 +4,8 @@ import { div, h, h2 } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonOutline, Link, Navbar } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
-import { AutoRefreshInterval, getDuration, isRunSetInTerminalState, makeStatusLine, statusType } from 'src/components/submission-common'
+import { AutoRefreshInterval, getDuration, isRunSetInTerminalState, loadRunSetData, makeStatusLine, statusType } from 'src/components/submission-common'
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table'
-import { Ajax } from 'src/libs/ajax'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
@@ -27,12 +26,11 @@ export const SubmissionHistory = () => {
   // helper for auto-refresh
   const refresh = Utils.withBusyState(setLoading, async () => {
     try {
-      const runSets = await Ajax(signal).Cbas.runSets.get()
-      const mergedRunSets = _.map(r => _.merge(r, { duration: getDuration(r.state, r.submission_timestamp, r.last_modified_timestamp, isRunSetInTerminalState) }), runSets.run_sets)
-      setRunSetData(mergedRunSets)
+      const loadedRunSetData = await loadRunSetData(signal)
+      setRunSetData(loadedRunSetData)
 
       // only refresh if there are Run Sets in non-terminal state
-      if (_.some(({ state }) => !isRunSetInTerminalState(state), mergedRunSets)) {
+      if (_.some(({ state }) => !isRunSetInTerminalState(state), loadedRunSetData)) {
         scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval)
       }
     } catch (error) {


### PR DESCRIPTION
Screenshots show the duration column when first submitted, after a minute, and after 2 minutes. Both the run durations and run set durations give the correct time when being auto-refreshed.

<img width="1577" alt="image" src="https://user-images.githubusercontent.com/68349264/222563443-9dd0568d-f913-44d8-a9ce-e0b2efe4535c.png">
<img width="1577" alt="image" src="https://user-images.githubusercontent.com/68349264/222563817-f4d83b74-e674-4319-b792-1df0c901b3d0.png">
<img width="1577" alt="image" src="https://user-images.githubusercontent.com/68349264/222564234-2084791a-81ef-4462-9ae5-f763f74329d4.png">

