### PR TITLE
WX-957 Remove call cache result column

### DIFF
--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -55,7 +55,7 @@ const statusCell = ({ calls }) => {
 }
 
 
-export const RunDetails = ({ namespace, name, submissionId, workflowId }) => {
+export const RunDetails = ({ submissionId, workflowId }) => {
   /*
    * State setup
    */
@@ -73,8 +73,8 @@ export const RunDetails = ({ namespace, name, submissionId, workflowId }) => {
   useOnMount(() => {
     const loadWorkflow = async () => {
       const includeKey = [
-        'end', 'executionStatus', 'failures', 'start', 'status', 'submittedFiles:workflow', 'workflowLog', 'workflowRoot', 'callCaching:result',
-        'callCaching:effectiveCallCachingMode', 'backendStatus'
+        'end', 'executionStatus', 'failures', 'start', 'status', 'submittedFiles:workflow', 'workflowLog', 'workflowRoot',
+        'backendStatus'
       ]
       const excludeKey = []
 
@@ -246,7 +246,7 @@ export const RunDetails = ({ namespace, name, submissionId, workflowId }) => {
                                 title: div({ style: { ...codeFont, ...elements.sectionHeader } }, [`${callName} × ${calls[callName].length}`]),
                                 initialOpenState: !every({ executionStatus: 'Done' }, calls[callName])
                               },
-                              [h(CallTable, { namespace, name, submissionId, workflowId, callName, callObjects: calls[callName] })]
+                              [h(CallTable, { callName, callObjects: calls[callName] })]
                             )
                           }, callNames)
                         ],

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
+import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Link, Select } from 'src/components/common'
@@ -8,13 +8,11 @@ import { collapseCromwellStatus, makeCromwellStatusLine } from 'src/components/j
 import { FlexTable, Sortable, tableHeight, TooltipCell } from 'src/components/table'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
-import CallCacheWizard from 'src/pages/workspaces/workspace/jobHistory/CallCacheWizard'
 import { FailuresModal } from 'src/pages/workspaces/workspace/jobHistory/FailuresViewer'
 
 
-const CallTable = ({ namespace, name, submissionId, workflowId, callName, callObjects }) => {
+const CallTable = ({ callName, callObjects }) => {
   const [failuresModalParams, setFailuresModalParams] = useState()
-  const [wizardSelection, setWizardSelection] = useState()
   const [sort, setSort] = useState({ field: 'index', direction: 'asc' })
   const [statusFilter, setStatusFilter] = useState([])
 
@@ -93,32 +91,6 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
           },
           {
             size: { basis: 200, grow: 2 },
-            field: 'callCachingResult',
-            headerRenderer: () => h(Sortable, { sort, field: 'callCachingResult', onSort: setSort }, ['Call Caching Result']),
-            cellRenderer: ({ rowIndex }) => {
-              const { shardIndex: index, callCaching: { effectiveCallCachingMode, result } = {} } = filteredCallObjects[rowIndex]
-              if (effectiveCallCachingMode === 'ReadAndWriteCache' || effectiveCallCachingMode === 'ReadCache') {
-                return result ? h(Fragment, [
-                  h(TooltipCell, [result]),
-                  result === 'Cache Miss' && h(Link, {
-                    key: 'cc',
-                    style: { marginLeft: '0.5rem' },
-                    tooltip: 'Call Cache Debug Wizard',
-                    onClick: () => setWizardSelection({ callFqn: callName, index })
-                  }, [
-                    icon('search', { size: 18 })
-                  ])
-                ]) :
-                  div({ style: { color: colors.dark(0.7) } }, ['No Information'])
-              } else if (effectiveCallCachingMode === 'WriteCache') {
-                return div({ style: { color: colors.dark(0.7) } }, ['Lookup disabled; write enabled'])
-              } else {
-                return div({ style: { color: colors.dark(0.7) } }, [effectiveCallCachingMode])
-              }
-            }
-          },
-          {
-            size: { basis: 200, grow: 2 },
             headerRenderer: () => 'Links',
             cellRenderer: ({ rowIndex }) => {
               const { failures, shardIndex: index, attempt } = filteredCallObjects[rowIndex]
@@ -137,8 +109,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
         ]
       })
     ]),
-    failuresModalParams && h(FailuresModal, { ...failuresModalParams, callFqn: callName, onDismiss: () => setFailuresModalParams(undefined) }),
-    wizardSelection && h(CallCacheWizard, { onDismiss: () => setWizardSelection(undefined), namespace, name, submissionId, workflowId, ...wizardSelection })
+    failuresModalParams && h(FailuresModal, { ...failuresModalParams, callFqn: callName, onDismiss: () => setFailuresModalParams(undefined) })
   ])
 }
 


### PR DESCRIPTION
<img width="1457" alt="Screen Shot 2023-03-03 at 1 28 11 PM" src="https://user-images.githubusercontent.com/3976514/222799114-779cf256-3fbe-4912-8788-fe6e38102520.png">

I removed the call caching related bits from the components the user sees, but left the now-unused CallCachingWizard in place since we'll be enabling call caching sometime in the near future. 

Note, the Links column is empty in this screenshot but contains stuff if the task fails.