### PR TITLE
WM-1773: Return up to 100 records from WDS record scan

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -111,7 +111,7 @@ const Cromwell = signal => ({
 // this hard-coded fallback UUID is a holdover from our local testing configuration.
 const wdsInstanceId = getConfig().wdsInstanceId || '15f36863-30a5-4cab-91f7-52be439f1175'
 const wdsApiVersion = getConfig().wdsApiVersion || 'v0.2'
-const searchPayload = {}
+const searchPayload = { limit: 100 }
 
 const Wds = signal => ({
   types: {


### PR DESCRIPTION
Not a long term fix, but should get us able to submit 100 workflows initially