### PR TITLE
Acknowledge submission within modal

### DIFF
--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -41,6 +41,7 @@ export const SubmissionConfig = ({ methodId }) => {
   // TODO: These should probably be moved to the modal:
   const [runSetName, setRunSetName] = useState('')
   const [runSetDescription, setRunSetDescription] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   // TODO: this should probably be moved to a scope more local to the data selector
   const [recordsTableSort, setRecordsTableSort] = useState({ field: 'id', direction: 'asc' })
@@ -234,18 +235,19 @@ export const SubmissionConfig = ({ methodId }) => {
       displayLaunchModal && h(Modal, {
         title: 'Send submission',
         width: 600,
-        onDismiss: () => setDisplayLaunchModal(false),
-        showCancel: true,
+        onDismiss: () => { if (!isSubmitting) { setDisplayLaunchModal(false) } },
+        showCancel: !isSubmitting,
         okButton:
           h(ButtonPrimary, {
-            disabled: false,
+            disabled: isSubmitting,
             'aria-label': 'Launch Submission',
             onClick: () => submitRun()
-          }, ['Submit'])
+          }, [ isSubmitting ? 'Submitting...' : 'Submit'])
       }, [
         div({ style: { lineHeight: 2.0 } }, [
           h(TextCell, { style: { marginTop: '1.5rem', fontSize: 16, fontWeight: 'bold' } }, ['Submission name']),
           h(TextInput, {
+            disabled: isSubmitting,
             'aria-label': 'Submission name',
             value: runSetName,
             onChange: setRunSetName,
@@ -258,6 +260,7 @@ export const SubmissionConfig = ({ methodId }) => {
           h(TextArea, {
             style: { height: 200, borderTopLeftRadius: 0, borderTopRightRadius: 0 },
             'aria-label': 'Enter a comment',
+            disabled: isSubmitting,
             value: runSetDescription,
             onChange: setRunSetDescription,
             placeholder: 'Enter comments'
@@ -321,7 +324,7 @@ export const SubmissionConfig = ({ methodId }) => {
         }
       }
 
-      setDisplayLaunchModal(false)
+      setIsSubmitting(true)
       const runSetObject = await Ajax(signal).Cbas.runSets.post(runSetsPayload)
       notify('success', 'Workflow successfully submitted', { message: 'You may check on the progress of workflow on this page anytime.', timeout: 5000 })
       Nav.goToPath('submission-details', {

--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -242,7 +242,7 @@ export const SubmissionConfig = ({ methodId }) => {
             disabled: isSubmitting,
             'aria-label': 'Launch Submission',
             onClick: () => submitRun()
-          }, [ isSubmitting ? 'Submitting...' : 'Submit'])
+          }, [isSubmitting ? 'Submitting...' : 'Submit'])
       }, [
         div({ style: { lineHeight: 2.0 } }, [
           h(TextCell, { style: { marginTop: '1.5rem', fontSize: 16, fontWeight: 'bold' } }, ['Submission name']),


### PR DESCRIPTION
### Changes:

- Elements on the submit modal are no longer enabled once submit is clicked.
- User cannot close the submit modal when submit is clicked.
- `Submit` changes to `Submitting...` when submit is clicked.

### Example screenshots:

#### Before clicking submit:
![image](https://user-images.githubusercontent.com/13006282/223826825-d5361613-b822-4784-a4ec-d0d5dead51de.png)

#### After clicking submit:
![image](https://user-images.githubusercontent.com/13006282/223826322-4d63daad-33c5-4ff4-bd1c-785e0090f6d7.png)
