### PR TITLE
[WM-1763] Make `appType` when resolving WDS proxy url configurable 

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -9,6 +9,7 @@ import { FlexTable, GridTable, HeaderCell, Resizable, Sortable, TextCell } from 
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { getConfig } from 'src/libs/config'
 import { notify } from 'src/libs/notifications'
 import * as Utils from 'src/libs/utils'
 import { differenceFromDatesInSeconds, differenceFromNowInSeconds } from 'src/libs/utils'
@@ -112,25 +113,25 @@ export const resolveWdsApp = apps => {
   // look explicitly for a RUNNING app named 'wds-${app.workspaceId}' -- if WDS is healthy and running, there should only be one app RUNNING
   // an app may be in the 'PROVISIONING', 'STOPPED', 'STOPPING', which can still be deemed as an OK state for WDS
   const healthyStates = ['RUNNING', 'PROVISIONING', 'STOPPED', 'STOPPING']
-  const namedApp = apps.filter(app => app.appType === 'CROMWELL' && app.appName === `wds-${app.workspaceId}` && healthyStates.includes(app.status))
+  const namedApp = apps.filter(app => app.appType === getConfig().wdsAppTypeName && app.appName === `wds-${app.workspaceId}` && healthyStates.includes(app.status))
   if (namedApp.length === 1) {
     return namedApp[0]
   }
 
-  //Failed to find an app with the proper name, look for a RUNNING CROMWELL app
-  const runningCromwellApps = apps.filter(app => app.appType === 'CROMWELL' && app.status === 'RUNNING')
-  if (runningCromwellApps.length > 0) {
+  //Failed to find an app with the proper name, look for a RUNNING WDS app
+  const runningWdsApps = apps.filter(app => app.appType === getConfig().wdsAppTypeName && app.status === 'RUNNING')
+  if (runningWdsApps.length > 0) {
     // Evaluate the earliest-created WDS app
-    runningCromwellApps.sort((a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf())
-    return runningCromwellApps[0]
+    runningWdsApps.sort((a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf())
+    return runningWdsApps[0]
   }
 
   // If we reach this logic, we have more than one Leo app with the associated workspace Id...
-  const allCromwellApps = apps.filter(app => app.appType === 'CROMWELL' && ['PROVISIONING', 'STOPPED', 'STOPPING'].includes(app.status))
-  if (allCromwellApps.length > 0) {
+  const allWdsApps = apps.filter(app => app.appType === getConfig().wdsAppTypeName && ['PROVISIONING', 'STOPPED', 'STOPPING'].includes(app.status))
+  if (allWdsApps.length > 0) {
     // Evaluate the earliest-created WDS app
-    allCromwellApps.sort((a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf())
-    return allCromwellApps[0]
+    allWdsApps.sort((a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf())
+    return allWdsApps[0]
   }
 
   return ''

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -1,4 +1,5 @@
 import { getDuration, isRunInTerminalState, isRunSetInTerminalState, resolveWdsUrl } from 'src/components/submission-common'
+import { getConfig } from 'src/libs/config'
 
 
 jest.mock('src/libs/config', () => ({
@@ -62,6 +63,10 @@ describe('resolveWdsUrl', () => {
     { appStatus: 'STOPPING', expectedUrl: '' },
     { appStatus: 'ERROR', expectedUrl: '' }
   ]
+
+  beforeEach(() => {
+    getConfig.mockReturnValue(({ wdsAppTypeName: 'CROMWELL' }))
+  })
 
   test.each(testCases)('properly extracts the correct value for a WDS app in \'$appStatus\' state from the Leo response ', ({ appStatus, expectedUrl }) => {
     const mockAppList = [generateMockApp('CROMWELL', appStatus, mockWdsProxyUrl, '2022-01-24T14:27:28.740880Z')]

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -1656,7 +1656,7 @@ describe('SubmissionConfig gets WDS url from Leo and render config page', () => 
   })
 
   beforeEach(() => {
-    getConfig.mockReturnValue(({ leoUrlRoot: 'https://leonardo.mock.org/' }))
+    getConfig.mockReturnValue(({ leoUrlRoot: 'https://leonardo.mock.org/', wdsAppTypeName: 'CROMWELL' }))
   })
 
   afterEach(() => {


### PR DESCRIPTION
When WDS and CBAS is decoupled, the app type for WDS will no longer be `CROMWELL`. Hence it will be better to have this configurable and only update the config value when that happens.

Closes https://broadworkbench.atlassian.net/browse/WM-1763