### PR TITLE
[WM-1837] Provide Covid-19 tutorial links for user in Submission Config page

### DIFF
--- a/src/components/HelpfulLinksBox.js
+++ b/src/components/HelpfulLinksBox.js
@@ -1,0 +1,39 @@
+import { div, h, h4, p } from 'react-hyperscript-helpers'
+import { Link } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { isCovid19Method } from 'src/components/submission-common'
+import colors from 'src/libs/colors'
+import * as Utils from 'src/libs/utils'
+
+
+const HelpfulLinksBox = ({ method }) => {
+  return div({ style: { backgroundColor: colors.accent(0.2), paddingTop: '0.25em', paddingBottom: '0.25em', paddingLeft: '1em', paddingRight: '1em' } }, [
+    h4('Have questions?'),
+    isCovid19Method(method.name) && p([
+      h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/12028928980123-Covid-19-Surveillance-tutorial-guide', ...Utils.newTabLinkProps },
+        [
+          'Covid-19 Surveillance tutorial guide',
+          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+        ]
+      )
+    ]),
+    isCovid19Method(method.name) && p([
+      h(Link, { href: 'https://app.terra.bio/#workspaces/azure-featured-workspaces/COVID-19-Surveillance', ...Utils.newTabLinkProps },
+        [
+          'Covid-19 Featured Workspace',
+          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+        ]
+      )
+    ]),
+    p([
+      h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/12029178977307-How-to-set-up-and-run-a-workflow', ...Utils.newTabLinkProps },
+        [
+          'How to set up and run a workflow',
+          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+        ]
+      )
+    ])
+  ])
+}
+
+export default HelpfulLinksBox

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -78,6 +78,9 @@ export const isRunSetInTerminalState = runSetStatus => RunSetTerminalStates.incl
 const RunTerminalStates = ['COMPLETE', 'CANCELED', 'SYSTEM_ERROR', 'ABORTED', 'EXECUTOR_ERROR']
 export const isRunInTerminalState = runStatus => RunTerminalStates.includes(runStatus)
 
+const Covid19Methods = ['fetch_sra_to_bam', 'assemble_refbased', 'sarscov2_nextstrain']
+export const isCovid19Method = methodName => Covid19Methods.includes(methodName)
+
 export const getDuration = (state, submissionDate, lastModifiedTimestamp, stateCheckCallback) => {
   return stateCheckCallback(state) ?
     differenceFromDatesInSeconds(submissionDate, lastModifiedTimestamp) :

--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -1,7 +1,8 @@
 import _ from 'lodash/fp'
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { a, div, h, h2, h4, p, span } from 'react-hyperscript-helpers'
+import { a, div, h, h2, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link, Navbar, Select } from 'src/components/common'
+import HelpfulLinksBox from 'src/components/HelpfulLinksBox'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { TextArea, TextInput } from 'src/components/input'
 import InputsTable from 'src/components/InputsTable'
@@ -9,7 +10,7 @@ import Modal from 'src/components/Modal'
 import OutputsTable from 'src/components/OutputsTable'
 import RecordsTable from 'src/components/RecordsTable'
 import StepButtons from 'src/components/StepButtons'
-import { isCovid19Method, resolveWdsUrl, WdsPollInterval } from 'src/components/submission-common'
+import { resolveWdsUrl, WdsPollInterval } from 'src/components/submission-common'
 import { TextCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -356,35 +357,7 @@ export const SubmissionConfig = ({ methodId }) => {
         ]),
         viewWorkflowScriptModal && h(ViewWorkflowScriptModal, { workflowScript, onDismiss: () => setViewWorkflowScriptModal(false) })
       ]),
-      div({ style: { marginRight: '1em' } }, [
-        div({ style: { backgroundColor: colors.accent(0.2), paddingTop: '0.25em', paddingBottom: '0.25em', paddingLeft: '1em', paddingRight: '1em' } }, [
-          h4('Have questions?'),
-          method && isCovid19Method(method.name) && p([
-            h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/12028928980123-Covid-19-Surveillance-tutorial-guide', ...Utils.newTabLinkProps },
-              [
-                'Covid-19 Surveillance tutorial guide',
-                icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-              ]
-            )
-          ]),
-          method && isCovid19Method(method.name) && p([
-            h(Link, { href: 'https://app.terra.bio/#workspaces/azure-featured-workspaces/COVID-19-Surveillance', ...Utils.newTabLinkProps },
-              [
-                'Covid-19 Featured Workspace',
-                icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-              ]
-            )
-          ]),
-          p([
-            h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/12029178977307-How-to-set-up-and-run-a-workflow', ...Utils.newTabLinkProps },
-              [
-                'How to set up and run a workflow',
-                icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-              ]
-            )
-          ])
-        ])
-      ])
+      method && div({ style: { marginRight: '1em' } }, [h(HelpfulLinksBox, { method })])
     ])
   }
 


### PR DESCRIPTION
For 3 Covid-19 workflows the Have Questions box will display below 3 links:
![Screenshot 2023-03-27 at 5 23 05 PM](https://user-images.githubusercontent.com/16748522/228069860-0a1fa25a-ed52-4878-a148-875e9f386f4c.png)


For all other workflows only this link will be displayed:
![Screenshot 2023-03-27 at 5 23 23 PM](https://user-images.githubusercontent.com/16748522/228069924-afcf37f5-cc07-4312-b5b3-1593dddd78d3.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1837