### PR TITLE
Fix Clipboard Button in Run Details

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -222,6 +222,7 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
       withErrorReporting('Error copying to clipboard'),
       Utils.withBusyState(setCopied)
     )(async e => {
+      e.stopPropagation()
       onClick?.(e)
       await clipboard.writeText(text)
       await Utils.delay(1500)

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -210,9 +210,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
                   {
                     style: { marginBottom: '1rem' },
                     initialOpenState: true,
-                    title: div({ style: elements.sectionHeader }, [
-                      'Workflow-Level Failures'
-                    ]),
+                    title: div({ style: elements.sectionHeader }, 'Workflow-Level Failures'),
                     afterTitle: h(ClipboardButton, {
                       text: JSON.stringify(failures, null, 2),
                       style: { marginLeft: '0.5rem' },

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -211,13 +211,13 @@ export const RunDetails = ({ submissionId, workflowId }) => {
                     style: { marginBottom: '1rem' },
                     initialOpenState: true,
                     title: div({ style: elements.sectionHeader }, [
-                      'Workflow-Level Failures',
-                      h(ClipboardButton, {
-                        text: JSON.stringify(failures, null, 2),
-                        style: { marginLeft: '0.5rem' },
-                        onClick: e => e.stopPropagation() // this stops the collapse when copying
-                      })
-                    ])
+                      'Workflow-Level Failures'
+                    ]),
+                    afterTitle: h(ClipboardButton, {
+                      text: JSON.stringify(failures, null, 2),
+                      style: { marginLeft: '0.5rem' },
+                      onClick: e => e.stopPropagation() // this stops the collapse when copying
+                    })
                   },
                   [
                     h(ReactJson, {

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -213,8 +213,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
                     title: div({ style: elements.sectionHeader }, 'Workflow-Level Failures'),
                     afterTitle: h(ClipboardButton, {
                       text: JSON.stringify(failures, null, 2),
-                      style: { marginLeft: '0.5rem' },
-                      onClick: e => e.stopPropagation() // this stops the collapse when copying
+                      style: { marginLeft: '0.5rem' }
                     })
                   },
                   [


### PR DESCRIPTION
Fixed an issue with a clipboard button in the Workflow Details page where it couldn't receive click events. [WX-1063]

Testing I did:
- Verified that the collapse menu still opens and closes when clicking anywhere (except on the clipboard button!) on the line with the title. 
- Verified that the clipboard button is visually in the right spot and does indeed copy stuff to your clipboard. 


https://broadworkbench.atlassian.net/browse/WX-1063?atlOrigin=eyJpIjoiY2NkNzMwNzBiNmM0NGJmODk3OWRkMTZhZTlmNDgyYzgiLCJwIjoiaiJ9

[WX-1063]: https://broadworkbench.atlassian.net/browse/WX-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ