### PR TITLE
[WM-1912] 0 is a valid value for Int and Float inputs

### DIFF
--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -339,10 +339,10 @@ const validateRequirements = (inputSource, inputType) => {
     }
     if (inputSource.type === 'literal') {
       // this condition is specifically added to allow '0' and 'false' as valid values because
-      // '!!inputSource.parameter_value' considers 0 and false as empty values
+      // '!!inputSource.parameter_value' considers '0' and 'false' as empty values
       // Note: '!=' null check also covers if value is undefined
       if (inputSource.parameter_value != null &&
-        (inputSource.parameter_value.toString() === '0' || inputSource.parameter_value.toString() === 'false')) {
+        (inputSource.parameter_value === 0 || inputSource.parameter_value === false)) {
         return true
       }
 

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -338,8 +338,15 @@ const validateRequirements = (inputSource, inputType) => {
       return _.every(Boolean, fieldsValidated)
     }
     if (inputSource.type === 'literal') {
-      // null check also covers if value is undefined
-      return inputSource.parameter_value != null && inputSource.parameter_value.toString().trim().length !== 0
+      // this condition is specifically added to allow '0' and 'false' as valid values because
+      // '!!inputSource.parameter_value' considers 0 and false as empty values
+      // Note: '!=' null check also covers if value is undefined
+      if (inputSource.parameter_value != null &&
+        (inputSource.parameter_value.toString() === '0' || inputSource.parameter_value.toString() === 'false')) {
+        return true
+      }
+
+      return !!inputSource.parameter_value
     }
   } else return false
 

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -334,7 +334,8 @@ const validateRequirements = (inputSource, inputType) => {
       return _.every(Boolean, fieldsValidated)
     }
     if (inputSource.type === 'literal') {
-      return !!inputSource.parameter_value
+      // null check also covers if value is undefined
+      return inputSource.parameter_value != null && inputSource.parameter_value.toString().trim().length !== 0
     }
   } else return false
 
@@ -370,7 +371,8 @@ export const convertToPrimitiveType = (primitiveType, value) => {
 
 export const isPrimitiveTypeInputValid = (primitiveType, value) => {
   return Utils.cond(
-    [primitiveType === 'Int', () => !isNaN(value) && Number.isInteger(Number(value))],
+    // last condition ensures empty strings are not accepted as valid Int because Number(value) in second condition converts empty strings to 0
+    [primitiveType === 'Int', () => !isNaN(value) && Number.isInteger(Number(value)) && !isNaN(parseInt(value))],
     [primitiveType === 'Float', () => !isNaN(value) && !isNaN(parseFloat(value))],
     [primitiveType === 'Boolean', () => value.toString().toLowerCase() === 'true' || value.toString().toLowerCase() === 'false'],
     () => true

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -229,8 +229,8 @@ describe('inputsWithIncorrectValues', () => {
 })
 
 describe('requiredInputsWithoutSource', () => {
-  const intInput = value => {
-    return {
+  it('should consider 0 as valid value', () => {
+    const validIntInput = {
       input_name: 'test_workflow.foo_int',
       input_type: {
         type: 'primitive',
@@ -238,88 +238,10 @@ describe('requiredInputsWithoutSource', () => {
       },
       source: {
         type: 'literal',
-        parameter_value: value
+        parameter_value: '0'
       }
     }
-  }
-
-  const floatInput = value => {
-    return {
-      input_name: 'test_workflow.bar_float',
-      input_type: {
-        type: 'optional',
-        optional_type: {
-          type: 'primitive',
-          primitive_type: 'Float'
-        }
-      },
-      source: {
-        type: 'literal',
-        parameter_value: value
-      }
-    }
-  }
-
-  const stringInput = value => {
-    return {
-      input_name: 'test_workflow.foo_string',
-      input_type: {
-        type: 'primitive',
-        primitive_type: 'String'
-      },
-      source: {
-        type: 'literal',
-        parameter_value: value
-      }
-    }
-  }
-
-  it('should return list of inputs that don\'t match requirements for required inputs and exclude optional inputs in check', () => {
-    const invalidIntInput = intInput('  ')
-    const invalidFloatInput = floatInput('wrong_value')
-    const invalidStringInput = stringInput('   ')
-    const inputsWithIncorrectValuesDefinition = [
-      invalidIntInput,
-      invalidFloatInput,
-      invalidStringInput
-    ]
-
-    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
-    expect(invalidInputs.length).toBe(2) // optional inputs are always considered valid in this function
-    expect(invalidInputs).toContain(invalidIntInput)
-    expect(invalidInputs).toContain(invalidStringInput)
-  })
-
-  it('should return list of inputs that don\'t match requirements for required inputs', () => {
-    const invalidIntInput = intInput('  ')
-    const invalidFloatInput = {
-      input_name: 'test_workflow.bar_float',
-      input_type: {
-        type: 'primitive',
-        primitive_type: 'Float'
-      },
-      source: {
-        type: 'literal',
-        parameter_value: '    '
-      }
-    }
-    const invalidStringInput = stringInput('   ')
-    const inputsWithIncorrectValuesDefinition = [
-      invalidIntInput,
-      invalidFloatInput,
-      invalidStringInput
-    ]
-
-    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
-    expect(invalidInputs.length).toBe(3)
-    expect(invalidInputs).toContain(invalidIntInput)
-    expect(invalidInputs).toContain(invalidFloatInput)
-    expect(invalidInputs).toContain(invalidStringInput)
-  })
-
-  it('should consider 0 as valid value', () => {
-    const invalidIntInput = intInput('0')
-    const invalidFloatInput = {
+    const validFloatInput = {
       input_name: 'test_workflow.bar_float',
       input_type: {
         type: 'primitive',
@@ -331,8 +253,8 @@ describe('requiredInputsWithoutSource', () => {
       }
     }
     const inputsWithIncorrectValuesDefinition = [
-      invalidIntInput,
-      invalidFloatInput
+      validIntInput,
+      validFloatInput
     ]
 
     const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -2,7 +2,7 @@ import {
   convertToPrimitiveType,
   getDuration, inputsWithIncorrectValues, isPrimitiveTypeInputValid,
   isRunInTerminalState,
-  isRunSetInTerminalState,
+  isRunSetInTerminalState, requiredInputsWithoutSource,
   resolveWdsUrl
 } from 'src/components/submission-common'
 import { getConfig } from 'src/libs/config'
@@ -95,7 +95,9 @@ describe('resolveWdsUrl', () => {
 
 describe('convertToPrimitiveType', () => {
   const testCases = [
+    { primitiveType: 'Int', value: '0', expectedTypeof: 'number', convertedValue: 0 },
     { primitiveType: 'Int', value: '123', expectedTypeof: 'number', convertedValue: 123 },
+    { primitiveType: 'Float', value: '0', expectedTypeof: 'number', convertedValue: 0 },
     { primitiveType: 'Float', value: '23.32', expectedTypeof: 'number', convertedValue: 23.32 },
     { primitiveType: 'Boolean', value: 'false', expectedTypeof: 'boolean', convertedValue: false },
     { primitiveType: 'String', value: 'hello world!', expectedTypeof: 'string', convertedValue: 'hello world!' },
@@ -111,15 +113,20 @@ describe('convertToPrimitiveType', () => {
 
 describe('isPrimitiveTypeInputValid', () => {
   const testCases = [
+    { primitiveType: 'Int', value: '0', expectedResult: true },
     { primitiveType: 'Int', value: '123', expectedResult: true },
     { primitiveType: 'Int', value: '123xHello', expectedResult: false },
     { primitiveType: 'Int', value: 'Hello', expectedResult: false },
     { primitiveType: 'Int', value: '1234.45', expectedResult: false },
+    { primitiveType: 'Int', value: '    ', expectedResult: false },
+    { primitiveType: 'Float', value: '0', expectedResult: true },
     { primitiveType: 'Float', value: '23.32', expectedResult: true },
     { primitiveType: 'Float', value: '23.0', expectedResult: true },
     { primitiveType: 'Float', value: '23', expectedResult: true },
     { primitiveType: 'Float', value: '23.0x', expectedResult: false },
     { primitiveType: 'Float', value: 'Hello', expectedResult: false },
+    { primitiveType: 'Float', value: '     ', expectedResult: false },
+    { primitiveType: 'Boolean', value: '   ', expectedResult: false },
     { primitiveType: 'Boolean', value: 'true', expectedResult: true },
     { primitiveType: 'Boolean', value: 'false', expectedResult: true },
     { primitiveType: 'Boolean', value: 'hello', expectedResult: false },
@@ -129,7 +136,7 @@ describe('isPrimitiveTypeInputValid', () => {
     { primitiveType: 'File', value: 'https://abc.wdl', expectedResult: true }
   ]
 
-  test.each(testCases)('returns if value for type $primitiveType is valid or not type as expected', ({ primitiveType, value, expectedResult }) => {
+  test.each(testCases)('returns if value \'$value\' for type $primitiveType is valid or not type as expected', ({ primitiveType, value, expectedResult }) => {
     expect(isPrimitiveTypeInputValid(primitiveType, value)).toBe(expectedResult)
   })
 })
@@ -201,6 +208,118 @@ describe('inputsWithIncorrectValues', () => {
     ]
 
     const invalidInputs = inputsWithIncorrectValues(inputsWithCorrectValuesDefinition)
+    expect(invalidInputs.length).toBe(0)
+  })
+})
+
+describe('requiredInputsWithoutSource', () => {
+  const intInput = value => {
+    return {
+      input_name: 'test_workflow.foo_int',
+      input_type: {
+        type: 'primitive',
+        primitive_type: 'Int'
+      },
+      source: {
+        type: 'literal',
+        parameter_value: value
+      }
+    }
+  }
+
+  const floatInput = value => {
+    return {
+      input_name: 'test_workflow.bar_float',
+      input_type: {
+        type: 'optional',
+        optional_type: {
+          type: 'primitive',
+          primitive_type: 'Float'
+        }
+      },
+      source: {
+        type: 'literal',
+        parameter_value: value
+      }
+    }
+  }
+
+  const stringInput = value => {
+    return {
+      input_name: 'test_workflow.foo_string',
+      input_type: {
+        type: 'primitive',
+        primitive_type: 'String'
+      },
+      source: {
+        type: 'literal',
+        parameter_value: value
+      }
+    }
+  }
+
+  it('should return list of inputs that don\'t match requirements for required inputs and exclude optional inputs in check', () => {
+    const invalidIntInput = intInput('  ')
+    const invalidFloatInput = floatInput('wrong_value')
+    const invalidStringInput = stringInput('   ')
+    const inputsWithIncorrectValuesDefinition = [
+      invalidIntInput,
+      invalidFloatInput,
+      invalidStringInput
+    ]
+
+    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
+    expect(invalidInputs.length).toBe(2) // optional inputs are always considered valid in this function
+    expect(invalidInputs).toContain(invalidIntInput)
+    expect(invalidInputs).toContain(invalidStringInput)
+  })
+
+  it('should return list of inputs that don\'t match requirements for required inputs', () => {
+    const invalidIntInput = intInput('  ')
+    const invalidFloatInput = {
+      input_name: 'test_workflow.bar_float',
+      input_type: {
+        type: 'primitive',
+        primitive_type: 'Float'
+      },
+      source: {
+        type: 'literal',
+        parameter_value: '    '
+      }
+    }
+    const invalidStringInput = stringInput('   ')
+    const inputsWithIncorrectValuesDefinition = [
+      invalidIntInput,
+      invalidFloatInput,
+      invalidStringInput
+    ]
+
+    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
+    expect(invalidInputs.length).toBe(3)
+    expect(invalidInputs).toContain(invalidIntInput)
+    expect(invalidInputs).toContain(invalidFloatInput)
+    expect(invalidInputs).toContain(invalidStringInput)
+  })
+
+  it('should consider 0 as valid value', () => {
+    const invalidIntInput = intInput('0')
+    const invalidFloatInput = {
+      input_name: 'test_workflow.bar_float',
+      input_type: {
+        type: 'primitive',
+        primitive_type: 'Float'
+      },
+      source: {
+        type: 'literal',
+        parameter_value: '0'
+      }
+    }
+    const inputsWithIncorrectValuesDefinition = [
+      invalidIntInput,
+      invalidFloatInput,
+    ]
+
+    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
     expect(invalidInputs.length).toBe(0)
   })
 })

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -229,7 +229,7 @@ describe('inputsWithIncorrectValues', () => {
 })
 
 describe('requiredInputsWithoutSource', () => {
-  it('should consider 0 as valid value', () => {
+  it('should consider 0 and false as valid value', () => {
     const validIntInput = {
       input_name: 'test_workflow.foo_int',
       input_type: {
@@ -238,7 +238,7 @@ describe('requiredInputsWithoutSource', () => {
       },
       source: {
         type: 'literal',
-        parameter_value: '0'
+        parameter_value: 0
       }
     }
     const validFloatInput = {
@@ -249,15 +249,26 @@ describe('requiredInputsWithoutSource', () => {
       },
       source: {
         type: 'literal',
-        parameter_value: '0'
+        parameter_value: 0
       }
     }
-    const inputsWithIncorrectValuesDefinition = [
+    const validBooleanInput = {
+      input_name: 'test_workflow.foo_boolean',
+      input_type: {
+        type: 'primitive',
+        primitive_type: 'Boolean'
+      },
+      source: {
+        type: 'literal',
+        parameter_value: false
+      }
+    }
+    const inputs = [
       validIntInput,
-      validFloatInput
+      validFloatInput,
+      validBooleanInput
     ]
 
-    const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)
-    expect(invalidInputs.length).toBe(0)
+    expect(requiredInputsWithoutSource(inputs).length).toBe(0)
   })
 })

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -332,7 +332,7 @@ describe('requiredInputsWithoutSource', () => {
     }
     const inputsWithIncorrectValuesDefinition = [
       invalidIntInput,
-      invalidFloatInput,
+      invalidFloatInput
     ]
 
     const invalidInputs = requiredInputsWithoutSource(inputsWithIncorrectValuesDefinition)


### PR DESCRIPTION
Tested locally:
![Screenshot 2023-04-19 at 6 23 39 PM](https://user-images.githubusercontent.com/16748522/233212744-56356383-4a98-4e63-8188-833beec908e0.png)

![Screenshot 2023-04-19 at 6 24 05 PM](https://user-images.githubusercontent.com/16748522/233212810-dc8e56af-cbbe-47f1-94a8-118c11419ee9.png)

0 is also valid for Float input
![Screenshot 2023-04-19 at 6 25 57 PM](https://user-images.githubusercontent.com/16748522/233213105-31b63a0c-9dae-4cdd-9ddd-6f9e9f80d35f.png)

Input definition passed to CBAS UI for Int input with value 0
```
"source": {
      "type": "object_builder",
      "fields": [
        {
          "name": "preemptible_tries",
          "source": {
            "type": "literal",
            "parameter_value": 0
          }
        },
        {
          "name": "agg_preemptible_tries",
          "source": {
            "type": "literal",
            "parameter_value": 4567
          }
        }
      ]
    }
```

Closes https://broadworkbench.atlassian.net/browse/WM-1912