### PR TITLE
[WX-1147] Fix File Not Found Error template on URIViewer

### DIFF
--- a/src/components/URIViewer/UriViewer.js
+++ b/src/components/URIViewer/UriViewer.js
@@ -20,7 +20,7 @@ import { UriPreview } from './UriPreview'
 // eslint-disable-next-line lodash-fp/no-single-composition
 export const UriViewer = _.flow(
   withDisplayName('UriViewer')
-)(({ uri, onDismiss }) => {
+)(({ uri, onDismiss, isStdLog }) => {
   const signal = useCancellation()
   const [metadata, setMetadata] = useState()
   const [loadingError, setLoadingError] = useState(false)
@@ -71,8 +71,10 @@ export const UriViewer = _.flow(
 
 
   const renderFailureMessage = () => {
+    const errorMsg = isStdLog ? 'Log file not found. This may be the result of a task failing to start. Please check relevant docker images and file paths to ensure valid references.' :
+      'Error loading data. This file does not exist or you do not have permission to view it.'
     return h(Fragment, [
-      div({ style: { paddingBottom: '1rem' } }, ['Error loading data. This file does not exist or you do not have permission to view it.'])
+      div({ style: { paddingBottom: '1rem' } }, [errorMsg])
       // below section should be re-enabled later on. Currently if a file is missing it's because Cromwell never fired up a task.
       // A static message should be enough to tackle this scenario for now.
       // h(Collapse, { title: 'Details' }, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -152,6 +152,12 @@ const AzureStorage = signal => ({
     const sasToken = await WorkspaceManager(signal).getSASToken()
     const url = `${blobFilepath}?${sasToken}`
     const res = await fetchAzureStorage(url, _.mergeAll([{ signal, method: 'GET' }]))
+    // Terra-UI and CBAS-UI use the Fetch API which treats any network response that returns as a resolved promise
+    // This is in contrast to other packages (ex: Axios) which treat any network response with a status code of 4xx or 5xx as a rejected promise
+    // Since the modal hinges on the file being returned, we'll treat any non-200 response as an error
+    if (res.status !== 200) {
+      throw new Error('Failed to fetch file from Azure Blob Storage')
+    }
     const textContent = await res.text()
     const blobDetails = parseAzureBlobUri(blobFilepath)
     const ret =

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -49,13 +49,15 @@ export const RunDetails = ({ submissionId, workflowId }) => {
   const [tableData, setTableData] = useState([])
   const [showLog, setShowLog] = useState(false)
   const [logUri, setLogUri] = useState({})
+  const [isStdLog, setIsStdLog] = useState(false)
 
   const signal = useCancellation()
   const stateRefreshTimer = useRef()
 
-  const showLogModal = useCallback(logUri => {
+  const showLogModal = useCallback((logUri, isStdLog = false) => {
     setLogUri(logUri)
     setShowLog(true)
+    setIsStdLog(isStdLog)
   }, [])
   /*
    * Data fetchers
@@ -165,7 +167,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
             })
           ]
         ),
-        showLog && h(UriViewer, { uri: logUri || '', onDismiss: () => setShowLog(false) })
+        showLog && h(UriViewer, { uri: logUri || '', onDismiss: () => setShowLog(false), isStdLog })
       ])
     )
   ])

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -248,6 +248,42 @@ describe('RunDetails - render smoke test', () => {
     })
   })
 
+  it('shows a static error message on UriViewer if stdout cannot be retrieved', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    altMockObj.AzureStorage.getTextFileFromBlobStorage = () => Promise.reject('Mock error')
+    Ajax.mockImplementation(() => altMockObj)
+    render(h(RunDetails, runDetailsProps))
+    const user = userEvent.setup()
+    await waitFor(async () => {
+      const table = screen.getByTestId('call-table-container')
+      expect(table).toBeDefined
+      const stdout = within(table).queryAllByText('stdout')
+      await user.click(stdout[0])
+      const modalTitle = screen.getByText('File Details')
+      expect(modalTitle).toBeDefined
+      const errorText = screen.getByText('Error loading data. This file does not exist or you do not have permission to view it.')
+      expect(errorText).toBeDefined
+    })
+  })
+
+  it('shows a static error message on UriViewer if stderr cannot be retrieved', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    altMockObj.AzureStorage.getTextFileFromBlobStorage = () => Promise.reject('Mock error')
+    Ajax.mockImplementation(() => altMockObj)
+    render(h(RunDetails, runDetailsProps))
+    const user = userEvent.setup()
+    await waitFor(async () => {
+      const table = screen.getByTestId('call-table-container')
+      expect(table).toBeDefined
+      const stderr = within(table).queryAllByText('stderr')
+      await user.click(stderr[0])
+      const modalTitle = screen.getByText('File Details')
+      expect(modalTitle).toBeDefined
+      const errorText = screen.getByText('Error loading data. This file does not exist or you do not have permission to view it.')
+      expect(errorText).toBeDefined
+    })
+  })
+
   it('opens the uri viewer modal when stderr is clicked', async () => {
     render(h(RunDetails, runDetailsProps))
     const user = userEvent.setup()

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -261,7 +261,7 @@ describe('RunDetails - render smoke test', () => {
       await user.click(stdout[0])
       const modalTitle = screen.getByText('File Details')
       expect(modalTitle).toBeDefined
-      const errorText = screen.getByText('Error loading data. This file does not exist or you do not have permission to view it.')
+      const errorText = screen.getByText('Log file not found. This may be the result of a task failing to start. Please check relevant docker images and file paths to ensure valid references.')
       expect(errorText).toBeDefined
     })
   })
@@ -279,7 +279,7 @@ describe('RunDetails - render smoke test', () => {
       await user.click(stderr[0])
       const modalTitle = screen.getByText('File Details')
       expect(modalTitle).toBeDefined
-      const errorText = screen.getByText('Error loading data. This file does not exist or you do not have permission to view it.')
+      const errorText = screen.getByText('Log file not found. This may be the result of a task failing to start. Please check relevant docker images and file paths to ensure valid references.')
       expect(errorText).toBeDefined
     })
   })

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -227,10 +227,10 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal }) => 
                   style: {
                     marginRight: '0.5rem'
                   },
-                  onClick: () => showLogModal(stdout)
+                  onClick: () => showLogModal(stdout, true)
                 }, ['stdout']),
                 h(Link, {
-                  onClick: () => showLogModal(stderr)
+                  onClick: () => showLogModal(stderr, true)
                 }, 'stderr')
               ])
             })


### PR DESCRIPTION
Addresses [WX-1147](https://broadworkbench.atlassian.net/browse/WX-1147)

PR fixes error message rendering on `URIViewer's` error message template when it fails to retrieve a file. This functionality is required in situations where `stdout` and `stderr` are not available because Cromwell was never able to start a task to begin with (usually due to errors like invalid/accessible docker images and/or inputs).

PR also adds tests to check against the expected functionality.

[WX-1147]: https://broadworkbench.atlassian.net/browse/WX-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ