### PR TITLE
[WM-2049] Struct Input Definition Separation 

### DIFF
--- a/src/components/StructBuilder.js
+++ b/src/components/StructBuilder.js
@@ -151,12 +151,14 @@ export const StructBuilder = props => {
             {
               headerRenderer: () => h(HeaderCell, ['Attribute']),
               cellRenderer: ({ rowIndex }) => {
+                // rowIndex is the index of this input in the currently displayed table
+                // configurationIndex is the index of this input the struct input definition
                 const configurationIndex = inputTableData[rowIndex].configurationIndex
                 const typeNamePath = buildStructTypeNamePath([configurationIndex])
                 const sourcePath = buildStructSourcePath([configurationIndex])
                 const sourceNamePath = buildStructSourceNamePath([configurationIndex])
                 const innerStructSource = _.get(sourcePath, currentStructSource)
-                const inputName = structInputDefinition[rowIndex].field_name
+                const inputName = inputTableData[rowIndex].field_name
                 const setInnerStructSource = source => {
                   const newSource = _.flow([
                     _.set(sourceNamePath, _.get(sourceNamePath, currentStructSource) || _.get(typeNamePath, currentStructType)),

--- a/src/components/StructBuilder.test.js
+++ b/src/components/StructBuilder.test.js
@@ -265,10 +265,10 @@ describe('Configuration tests', () => {
     const structTable = await screen.getByLabelText('struct-table')
     const structRows = within(structTable).queryAllByRole('row')
     expect(structRows.length).toBe(3)
-    within(structRows[1]).getByText('pet_description')
-    within(structRows[2]).getByText('pet_age')
+    within(structRows[1]).getByText('pet_age')
+    within(structRows[2]).getByText('pet_description')
 
-    const structCells = within(structRows[1]).queryAllByRole('cell')
+    const structCells = within(structRows[2]).queryAllByRole('cell')
     within(structCells[3]).getByText('Use Struct Builder')
 
     // ** ACT **
@@ -280,8 +280,8 @@ describe('Configuration tests', () => {
     const innerStructTable = await screen.getByLabelText('struct-table')
     const innerStructRows = within(innerStructTable).queryAllByRole('row')
     expect(innerStructRows.length).toBe(3)
-    within(innerStructRows[1]).getByText('pet_num_legs')
-    within(innerStructRows[2]).getByText('pet_has_tail')
+    within(innerStructRows[1]).getByText('pet_has_tail')
+    within(innerStructRows[2]).getByText('pet_num_legs')
 
     // ** ACT **
     // go back up a level by clicking 'Back'
@@ -294,8 +294,8 @@ describe('Configuration tests', () => {
     const outerStructTable = await screen.getByLabelText('struct-table')
     const outerStructRows = within(outerStructTable).queryAllByRole('row')
     expect(outerStructRows.length).toBe(3)
-    within(outerStructRows[1]).getByText('pet_description')
-    within(outerStructRows[2]).getByText('pet_age')
+    within(outerStructRows[1]).getByText('pet_age')
+    within(outerStructRows[2]).getByText('pet_description')
 
     // ** ACT **
     // exit modal by clicking 'Done'

--- a/src/libs/mock-responses.js
+++ b/src/libs/mock-responses.js
@@ -229,8 +229,7 @@ export const myStructInput = {
             {
               name: 'myInnermostPrimitive',
               source: {
-                type: 'literal',
-                parameter_value: 'foo'
+                type: 'none'
               }
             },
             {

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -913,7 +913,7 @@ describe('Input source and requirements validation', () => {
     const structRows = within(structTable).queryAllByRole('row')
     expect(structRows.length).toBe(6)
 
-    const structCells = within(structRows[5]).queryAllByRole('cell')
+    const structCells = within(structRows[2]).queryAllByRole('cell')
     within(structCells[1]).getByText('myInnerStruct')
     const viewMyInnerStructLink = within(structCells[4]).getByText('View Struct')
     const structWarningMessageActive = within(structCells[4]).queryByText("One of this struct's inputs has an invalid configuration")
@@ -1022,10 +1022,10 @@ describe('Input source and requirements validation', () => {
     expect(innerStructRows.length).toBe(3)
 
     // check that warnings appear next to empty required inputs inside struct modal
-    const innerStructRow1Cells = within(innerStructRows[1]).queryAllByRole('cell')
+    const innerStructRow1Cells = within(innerStructRows[2]).queryAllByRole('cell')
     within(innerStructRow1Cells[4]).getByText('This input is required')
 
-    const innerStructRow2Cells = within(innerStructRows[2]).queryAllByRole('cell')
+    const innerStructRow2Cells = within(innerStructRows[1]).queryAllByRole('cell')
     within(innerStructRow2Cells[4]).getByText('Optional')
 
     // ** ACT **
@@ -1780,7 +1780,7 @@ describe('SubmissionConfig inputs/outputs definitions', () => {
     within(headers[3]).getByText('Input sources')
     within(headers[4]).getByText('Attribute')
 
-    const structCells = within(structRows[5]).queryAllByRole('cell')
+    const structCells = within(structRows[2]).queryAllByRole('cell')
     within(structCells[1]).getByText('myInnerStruct')
     const viewMyInnerStructLink = within(structCells[4]).getByText('View Struct')
 
@@ -2188,7 +2188,7 @@ describe('SubmissionConfig submitting a run set', () => {
 
     // ** ACT **
     // Update the top-level struct field myPrimitive
-    const myPrimitiveRowCells = within(structRows[1]).queryAllByRole('cell')
+    const myPrimitiveRowCells = within(structRows[5]).queryAllByRole('cell')
     within(myPrimitiveRowCells[1]).getByText('myPrimitive')
     const myPrimitiveInput = within(myPrimitiveRowCells[4]).getByDisplayValue('Fiesty')
     await fireEvent.change(myPrimitiveInput, { target: { value: 'Docile' } })
@@ -2196,7 +2196,7 @@ describe('SubmissionConfig submitting a run set', () => {
 
     // ** ACT **
     // Navigate the struct builder to myInnerStruct
-    const myInnerStructRowCells = within(structRows[5]).queryAllByRole('cell')
+    const myInnerStructRowCells = within(structRows[2]).queryAllByRole('cell')
     within(myInnerStructRowCells[1]).getByText('myInnerStruct')
     const viewMyInnerStructLink = within(myInnerStructRowCells[4]).getByText('View Struct')
     await fireEvent.click(viewMyInnerStructLink)

--- a/src/pages/SubmissionConfig.test.js
+++ b/src/pages/SubmissionConfig.test.js
@@ -904,7 +904,7 @@ describe('Input source and requirements validation', () => {
     const table = await screen.findByRole('table')
     const rows = within(table).queryAllByRole('row')
     const viewStructLink = within(rows[2]).getByText('View Struct')
-    const inputWarningMessageActive = within(rows[2]).queryByText("One of this struct's inputs has an invalid configuration")
+    const inputWarningMessageActive = within(rows[2]).queryByText('This struct is missing a required input')
     expect(inputWarningMessageActive).not.toBeNull()
 
     // ** ACT **
@@ -918,7 +918,7 @@ describe('Input source and requirements validation', () => {
     const structCells = within(structRows[2]).queryAllByRole('cell')
     within(structCells[1]).getByText('myInnerStruct')
     const viewMyInnerStructLink = within(structCells[4]).getByText('View Struct')
-    const structWarningMessageActive = within(structCells[4]).getByText("One of this struct's inputs has an invalid configuration")
+    const structWarningMessageActive = within(structCells[4]).getByText('This struct is missing a required input')
     expect(structWarningMessageActive).not.toBeNull()
 
     // ** ACT **
@@ -2367,7 +2367,12 @@ describe('SubmissionConfig submitting a run set', () => {
     // Update the struct within myInnerStruct
     const myInnermostPrimitiveRowCells = within(myInnerStructRows[1]).queryAllByRole('cell')
     within(myInnermostPrimitiveRowCells[1]).getByText('myInnermostPrimitive')
-    const myInnermostPrimitiveInput = within(myInnermostPrimitiveRowCells[4]).getByDisplayValue('foo')
+    await act(async () => {
+      await userEvent.click(within(myInnermostPrimitiveRowCells[3]).getByText('Select Source'))
+      const selectOption = await within(screen.getByRole('listbox')).findByText('Type a Value')
+      await userEvent.click(selectOption)
+    })
+    const myInnermostPrimitiveInput = within(myInnermostPrimitiveRowCells[4]).getByLabelText('Enter a value')
     await fireEvent.change(myInnermostPrimitiveInput, { target: { value: 'bar' } })
     within(myInnermostPrimitiveRowCells[4]).getByDisplayValue('bar')
 


### PR DESCRIPTION
Addressed bug by adding an `inputTableData` variable to StructBuilder analogous to that of the InputsTable, introducing the ability to modify the rows displayed to the user without altering the underlying input type and source definitions. 