### PR TITLE
[WM-2008] View Workflow Script modal supports viewing Dockstore and Github workflows

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -6,5 +6,5 @@
   "workspaceManagerRoot" : "",
   "workspaceId" : "",
   "containerResourceId" : "",
-  "dockstoreRootUrl" :  "https://staging.dockstore.org/search?descriptorType=WDL&entryType=workflows&searchMode=files"
+  "dockstoreRootUrl" :  "https://staging.dockstore.org"
 }

--- a/public/config.json
+++ b/public/config.json
@@ -6,5 +6,5 @@
   "workspaceManagerRoot" : "",
   "workspaceId" : "",
   "containerResourceId" : "",
-  "dockstoreRootUrl" :  "https://staging.dockstore.org"
+  "dockstoreRootUrl" : "https://staging.dockstore.org/"
 }

--- a/src/components/method-common.js
+++ b/src/components/method-common.js
@@ -32,7 +32,7 @@ export const submitMethod = async (signal, onDismiss, method) => {
 
 export const convertToRawUrl = (methodPath, methodVersion, methodSource) => {
   return Utils.cond(
-    // 3 Covid-19 workflows have 'Github' as source hence we check for that here to maintain backwards compatibility
+    // the case-insensitive check is to maintain backwards compatibility as 3 Covid-19 workflows have 'Github' as source
     [methodSource.toLowerCase() === MethodSource.GitHub.toLowerCase(), () => {
       // mapping of searchValues (key) and their replaceValue (value)
       const mapObj = {

--- a/src/components/method-common.js
+++ b/src/components/method-common.js
@@ -33,7 +33,7 @@ export const submitMethod = async (signal, onDismiss, method) => {
 export const convertToRawUrl = (methodPath, methodVersion, methodSource) => {
   return Utils.cond(
     // 3 Covid-19 workflows have 'Github' as source hence we check for that here to maintain backwards compatibility
-    [methodSource === MethodSource.GitHub || methodSource === 'Github', () => {
+    [methodSource.toLowerCase() === MethodSource.GitHub.toLowerCase(), () => {
       // mapping of searchValues (key) and their replaceValue (value)
       const mapObj = {
         github: 'raw.githubusercontent',
@@ -41,7 +41,7 @@ export const convertToRawUrl = (methodPath, methodVersion, methodSource) => {
       }
       return methodPath.replace(/\b(?:github|blob\/)\b/gi, matched => mapObj[matched])
     }],
-    [methodSource === MethodSource.Dockstore, async () => await Ajax().Dockstore.getWorkflowSourceUrl(methodPath, methodVersion)],
+    [methodSource.toLowerCase() === MethodSource.Dockstore.toLowerCase(), async () => await Ajax().Dockstore.getWorkflowSourceUrl(methodPath, methodVersion)],
     () => {
       throw new Error(`Unknown method source '${methodSource}'. Currently supported method sources are [${MethodSource.GitHub}, ${MethodSource.Dockstore}].`)
     }

--- a/src/components/method-common.test.js
+++ b/src/components/method-common.test.js
@@ -1,6 +1,7 @@
 import {
-  reconstructToRawUrl
+  convertToRawUrl
 } from 'src/components/method-common'
+import { Ajax } from 'src/libs/ajax'
 
 
 jest.mock('src/libs/config', () => ({
@@ -8,18 +9,63 @@ jest.mock('src/libs/config', () => ({
   getConfig: jest.fn().mockReturnValue({})
 }))
 
-describe('reconstructToRawUrl', () => {
-  const validRawUrl = 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
+jest.mock('src/libs/ajax')
 
-  const testCases = [
-    { url: 'lol.com', expectedUrl: 'lol.com' },
-    { url: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl', expectedUrl: validRawUrl },
-    { url: 'https://github.com/broadinstitute/cromwell/blob/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl', expectedUrl: validRawUrl }
+describe('convertToRawUrl', () => {
+  const nonDockstoreValidTestCases = [
+    {
+      methodPath: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl',
+      methodVersion: 'develop',
+      methodSource: 'GitHub',
+      expectedRawUrl: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
+    },
+    {
+      methodPath: 'https://github.com/broadinstitute/cromwell/blob/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl',
+      methodVersion: 'develop',
+      methodSource: 'GitHub',
+      expectedRawUrl: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
+    }
   ]
 
-  test.each(testCases)('returns reconstructed url', ({ url, expectedUrl }) => {
-    const onDismiss = jest.fn()
-    const reconstructedUrl = reconstructToRawUrl(url, onDismiss)
-    expect(reconstructedUrl).toBe(expectedUrl)
+  test.each(nonDockstoreValidTestCases)('returns raw URL for GitHub source', ({ methodPath, methodVersion, methodSource, expectedRawUrl }) => {
+    expect(convertToRawUrl(methodPath, methodVersion, methodSource)).toBe(expectedRawUrl)
+  })
+
+
+  it('should call Dockstore to retrive raw URL', async () => {
+    const mockDockstoreResponse = 'https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl'
+
+    const methodPath = 'github.com/broadinstitute/viral-pipelines/fetch_sra_to_bam'
+    const methodVersion = 'master'
+    const methodSource = 'Dockstore'
+    const expectedRawUrl = 'https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl'
+
+    const mockDockstoreWfSourceMethod = jest.fn(() => Promise.resolve(mockDockstoreResponse))
+
+    Ajax.mockImplementation(() => {
+      return {
+        Dockstore: {
+          getWorkflowSourceUrl: mockDockstoreWfSourceMethod
+        }
+      }
+    })
+
+    const actualUrl = await convertToRawUrl(methodPath, methodVersion, methodSource)
+
+    expect(mockDockstoreWfSourceMethod).toBeCalledTimes(1)
+    expect(mockDockstoreWfSourceMethod).toHaveBeenCalledWith(methodPath, methodVersion)
+    expect(actualUrl).toBe(expectedRawUrl)
+  })
+
+  it('should throw error for unknown method source', () => {
+    const methodPath = 'https://my-website/hello-world.wdl'
+    const methodVersion = 'develop'
+    const methodSource = 'MySource'
+
+    try {
+      convertToRawUrl(methodPath, methodVersion, methodSource)
+    } catch (e) {
+      expect(e.message).toBe("Unknown method source 'MySource'. Currently supported method sources are [GitHub, Dockstore].")
+    }
   })
 })

--- a/src/components/method-common.test.js
+++ b/src/components/method-common.test.js
@@ -13,6 +13,7 @@ jest.mock('src/libs/ajax')
 
 describe('convertToRawUrl', () => {
   const nonDockstoreValidTestCases = [
+    // "GitHub" as source
     {
       methodPath: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl',
       methodVersion: 'develop',
@@ -24,6 +25,19 @@ describe('convertToRawUrl', () => {
       methodVersion: 'develop',
       methodSource: 'GitHub',
       expectedRawUrl: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
+    },
+    // "Github" as source
+    {
+      methodPath: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl',
+      methodVersion: 'develop',
+      methodSource: 'Github',
+      expectedRawUrl: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
+    },
+    {
+      methodPath: 'https://github.com/broadinstitute/cromwell/blob/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl',
+      methodVersion: 'develop',
+      methodSource: 'Github',
+      expectedRawUrl: 'https://raw.githubusercontent.com/broadinstitute/cromwell/develop/wdl/transforms/draft3/src/test/cases/simple_task.wdl'
     }
   ]
 
@@ -33,14 +47,12 @@ describe('convertToRawUrl', () => {
 
 
   it('should call Dockstore to retrive raw URL', async () => {
-    const mockDockstoreResponse = 'https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl'
-
     const methodPath = 'github.com/broadinstitute/viral-pipelines/fetch_sra_to_bam'
     const methodVersion = 'master'
     const methodSource = 'Dockstore'
-    const expectedRawUrl = 'https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl'
+    const rawUrl = 'https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl'
 
-    const mockDockstoreWfSourceMethod = jest.fn(() => Promise.resolve(mockDockstoreResponse))
+    const mockDockstoreWfSourceMethod = jest.fn(() => Promise.resolve(rawUrl))
 
     Ajax.mockImplementation(() => {
       return {
@@ -54,7 +66,7 @@ describe('convertToRawUrl', () => {
 
     expect(mockDockstoreWfSourceMethod).toBeCalledTimes(1)
     expect(mockDockstoreWfSourceMethod).toHaveBeenCalledWith(methodPath, methodVersion)
-    expect(actualUrl).toBe(expectedRawUrl)
+    expect(actualUrl).toBe(rawUrl)
   })
 
   it('should throw error for unknown method source', () => {

--- a/src/libs/ajax-fetch.js
+++ b/src/libs/ajax-fetch.js
@@ -49,3 +49,4 @@ export const fetchWds = wdsUrlRoot => withUrlPrefix(`${wdsUrlRoot}/`, fetchOk)
 const wsmRoot = `${getConfig().workspaceManagerRoot}/api/workspaces/v1`
 export const fetchWorkspaceManager = withUrlPrefix(`${wsmRoot}/`, fetchOk)
 export const fetchAzureStorage = withUrlPrefix('', fetchOk)
+export const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreRootUrl}/api/`, fetchOk)

--- a/src/libs/ajax-fetch.js
+++ b/src/libs/ajax-fetch.js
@@ -49,4 +49,4 @@ export const fetchWds = wdsUrlRoot => withUrlPrefix(`${wdsUrlRoot}/`, fetchOk)
 const wsmRoot = `${getConfig().workspaceManagerRoot}/api/workspaces/v1`
 export const fetchWorkspaceManager = withUrlPrefix(`${wsmRoot}/`, fetchOk)
 export const fetchAzureStorage = withUrlPrefix('', fetchOk)
-export const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreRootUrl}/api/`, fetchOk)
+export const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreRootUrl}api/`, fetchOk)

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,6 +1,15 @@
 import _ from 'lodash/fp'
 import qs from 'qs'
-import { fetchAzureStorage, fetchCbas, fetchCromwell, fetchLeo, fetchOk, fetchWds, fetchWorkspaceManager } from 'src/libs/ajax-fetch'
+import {
+  fetchAzureStorage,
+  fetchCbas,
+  fetchCromwell,
+  fetchDockstore,
+  fetchLeo,
+  fetchOk,
+  fetchWds,
+  fetchWorkspaceManager
+} from 'src/libs/ajax-fetch'
 import { getConfig } from 'src/libs/config'
 import { parseAzureBlobUri } from 'src/libs/utils'
 
@@ -177,6 +186,16 @@ const AzureStorage = signal => ({
   }
 })
 
+const Dockstore = signal => ({
+  getWorkflowSourceUrl: async (path, version) => {
+    // %23 = '#', %2F = '/'
+    const workflowVersionsPath = `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
+    const wdlPath = `${workflowVersionsPath}/${encodeURIComponent(version)}/WDL/descriptor`
+    const { url } = await fetchDockstore(wdlPath, { signal }).then(res => res.json())
+    return url
+  }
+})
+
 export const Ajax = signal => {
   return {
     Cbas: Cbas(signal),
@@ -185,6 +204,7 @@ export const Ajax = signal => {
     WorkflowScript: WorkflowScript(signal),
     Leonardo: Leonardo(signal),
     WorkspaceManager: WorkspaceManager(signal),
-    AzureStorage: AzureStorage(signal)
+    AzureStorage: AzureStorage(signal),
+    Dockstore: Dockstore(signal)
   }
 }

--- a/src/pages/FindWorkflow/FindWorkflowModal.js
+++ b/src/pages/FindWorkflow/FindWorkflowModal.js
@@ -118,7 +118,7 @@ const FindWorkflowModal = ({ onDismiss }) => {
         ])
       ]),
       isSubHeaderActive('add-a-workflow-link') && h(ImportGithub, { setLoading, signal, onDismiss }),
-      isSubHeaderActive('go-to-dockstore') && div({ style: { marginLeft: '4rem', width: '50%' } }, [h(ButtonPrimary, { style: { width: 225 }, href: getConfig().dockstoreRootUrl }, ['Go to Dockstore'])]),
+      isSubHeaderActive('go-to-dockstore') && div({ style: { marginLeft: '4rem', width: '50%' } }, [h(ButtonPrimary, { style: { width: 225 }, href: `${getConfig().dockstoreRootUrl}/search?_type=workflow&descriptorType=WDL&searchMode=files` }, ['Go to Dockstore'])]),
       div({ style: { marginLeft: '10rem', marginRight: '1.5rem', width: '40%' } }, [h(HelpfulLinksBox)])
     ])
   ])

--- a/src/pages/FindWorkflow/FindWorkflowModal.js
+++ b/src/pages/FindWorkflow/FindWorkflowModal.js
@@ -118,7 +118,7 @@ const FindWorkflowModal = ({ onDismiss }) => {
         ])
       ]),
       isSubHeaderActive('add-a-workflow-link') && h(ImportGithub, { setLoading, signal, onDismiss }),
-      isSubHeaderActive('go-to-dockstore') && div({ style: { marginLeft: '4rem', width: '50%' } }, [h(ButtonPrimary, { style: { width: 225 }, href: `${getConfig().dockstoreRootUrl}/search?_type=workflow&descriptorType=WDL&searchMode=files` }, ['Go to Dockstore'])]),
+      isSubHeaderActive('go-to-dockstore') && div({ style: { marginLeft: '4rem', width: '50%' } }, [h(ButtonPrimary, { style: { width: 225 }, href: `${getConfig().dockstoreRootUrl}search?_type=workflow&descriptorType=WDL&searchMode=files` }, ['Go to Dockstore'])]),
       div({ style: { marginLeft: '10rem', marginRight: '1.5rem', width: '40%' } }, [h(HelpfulLinksBox)])
     ])
   ])

--- a/src/pages/FindWorkflow/FindWorkflowModal.test.js
+++ b/src/pages/FindWorkflow/FindWorkflowModal.test.js
@@ -20,7 +20,7 @@ describe('FindWorkflowModal', () => {
   beforeEach(() => {
     getConfig.mockReturnValue({ isDockstoreEnabled: false })
     getConfig.mockReturnValue({ isURLEnabled: false })
-    getConfig.mockReturnValue(({ dockstoreRootUrl: 'https://staging.dockstore.org' }))
+    getConfig.mockReturnValue(({ dockstoreRootUrl: 'https://staging.dockstore.org/' }))
   })
   it('should render FindWorkflowModal with 5 hardcoded Method cards', () => {
     // ** ACT **

--- a/src/pages/FindWorkflow/FindWorkflowModal.test.js
+++ b/src/pages/FindWorkflow/FindWorkflowModal.test.js
@@ -20,7 +20,7 @@ describe('FindWorkflowModal', () => {
   beforeEach(() => {
     getConfig.mockReturnValue({ isDockstoreEnabled: false })
     getConfig.mockReturnValue({ isURLEnabled: false })
-    getConfig.mockReturnValue(({ dockstoreRootUrl: 'https://staging.dockstore.org/search?descriptorType=WDL&entryType=workflows&searchMode=files' }))
+    getConfig.mockReturnValue(({ dockstoreRootUrl: 'https://staging.dockstore.org' }))
   })
   it('should render FindWorkflowModal with 5 hardcoded Method cards', () => {
     // ** ACT **
@@ -89,6 +89,6 @@ describe('FindWorkflowModal', () => {
     fireEvent.click(dockstoreSubHeader)
 
     const dockstoreButton = screen.getByText('Go to Dockstore')
-    expect(dockstoreButton).toHaveAttribute('href', 'https://staging.dockstore.org/search?descriptorType=WDL&entryType=workflows&searchMode=files')
+    expect(dockstoreButton).toHaveAttribute('href', 'https://staging.dockstore.org/search?_type=workflow&descriptorType=WDL&searchMode=files')
   })
 })

--- a/src/pages/SubmissionConfig.js
+++ b/src/pages/SubmissionConfig.js
@@ -7,7 +7,7 @@ import HelpfulLinksBox from 'src/components/HelpfulLinksBox'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { TextArea, TextInput } from 'src/components/input'
 import InputsTable from 'src/components/InputsTable'
-import { reconstructToRawUrl } from 'src/components/method-common'
+import { convertToRawUrl } from 'src/components/method-common'
 import Modal from 'src/components/Modal'
 import OutputsTable from 'src/components/OutputsTable'
 import RecordsTable from 'src/components/RecordsTable'
@@ -224,7 +224,7 @@ export const SubmissionConfig = ({ methodId }) => {
   useEffect(() => {
     async function getWorkflowScript() {
       try {
-        const workflowUrlRaw = reconstructToRawUrl(selectedMethodVersion.url)
+        const workflowUrlRaw = await convertToRawUrl(selectedMethodVersion.url, selectedMethodVersion.name, method.source)
         const script = await Ajax(signal).WorkflowScript.get(workflowUrlRaw)
         setWorkflowScript(script)
       } catch (error) {
@@ -235,7 +235,7 @@ export const SubmissionConfig = ({ methodId }) => {
     if (selectedMethodVersion != null) {
       getWorkflowScript()
     }
-  }, [signal, selectedMethodVersion])
+  }, [signal, selectedMethodVersion, method])
 
   useEffect(() => {
     // Start polling if we're missing WDS proxy url and stop polling when we have it


### PR DESCRIPTION
Tested locally:
Viewing workflow with Raw Github url source (this workflow is the pre-staged one)
Source: https://raw.githubusercontent.com/broadinstitute/viral-pipelines/v2.1.33.16/pipes/WDL/workflows/fetch_sra_to_bam.wdl
<img src="https://github.com/DataBiosphere/cbas-ui/assets/16748522/07589ece-9cb0-49af-89a9-5e579f637496" width="1100" height="500" />

Viewing workflow with Github url source
Source: https://github.com/broadinstitute/viral-pipelines/blob/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl
<img src="https://github.com/DataBiosphere/cbas-ui/assets/16748522/7c86efdc-de05-481f-a54e-651d4c2c3a5e" width="1100" height="500" />

Viewing workflow with Dockstore source
Source: github.com/broadinstitute/viral-pipelines/fetch_sra_to_bam
<img src="https://github.com/DataBiosphere/cbas-ui/assets/16748522/b6f46781-2e00-4227-b7f3-97054ae65659" width="1100" height="500" />


Closes https://broadworkbench.atlassian.net/browse/WM-2008