### PR TITLE
[WX-1162] Fix render crash

### DIFF
--- a/src/components/InputOutputModal.js
+++ b/src/components/InputOutputModal.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Link } from 'src/components/common'
@@ -19,9 +20,9 @@ export const appendSASTokenIfNecessary = (blobPath, sasToken) => {
 }
 
 //Whatever is after the last slash is the filename.
+//If there is no slash, the entire string will be returned.
 export const getFilenameFromAzureBlobPath = blobPath => {
-  const n = blobPath.lastIndexOf('/')
-  return blobPath.substring(n + 1) //If there is no slash, this returns the whole string.
+  return _.isString(blobPath) ? blobPath.substring(blobPath.lastIndexOf('/') + 1) : ''
 }
 
 const InputOutputModal = ({ title, jsonData, onDismiss, sasToken }) => {

--- a/src/components/InputOutputModal.js
+++ b/src/components/InputOutputModal.js
@@ -20,7 +20,6 @@ export const appendSASTokenIfNecessary = (blobPath, sasToken) => {
 }
 
 //Whatever is after the last slash is the filename.
-//If there is no slash, the entire string will be returned.
 export const getFilenameFromAzureBlobPath = blobPath => {
   return _.isString(blobPath) ? blobPath.substring(blobPath.lastIndexOf('/') + 1) : ''
 }
@@ -32,6 +31,7 @@ const InputOutputModal = ({ title, jsonData, onDismiss, sasToken }) => {
     const fileName = getFilenameFromAzureBlobPath(blobPath)
     return h(Link, {
       disabled: !downloadUrl,
+      isRendered: !_.isEmpty(fileName),
       href: downloadUrl,
       download: fileName,
       style: {},

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -417,6 +417,8 @@ describe('RunDetails - render smoke test', () => {
     const privateFilename = getFilenameFromAzureBlobPath(privateURI)
     expect(publicFilename).toEqual('ref-sarscov2-NC_045512.2.fasta')
     expect(privateFilename).toEqual('stdout')
+    expect(getFilenameFromAzureBlobPath('')).toEqual('')
+    expect(getFilenameFromAzureBlobPath(undefined)).toEqual('')
 
     //Should only append SAS if it is a private URI
     const appendedPublic = appendSASTokenIfNecessary(publicURI, mockSAS)


### PR DESCRIPTION
Fixed a sneaky crash in the WorkflowDetails page. Under very specific conditions, it was possible for an `undefined` to exist during a page re-render, displaying the contents of a modal before it was fully loaded. 