### PR TITLE
WX-1111 [risk=no] Added workflow explorer to RunDetails page

### DIFF
--- a/src/components/WorkflowInfoBox.js
+++ b/src/components/WorkflowInfoBox.js
@@ -30,8 +30,8 @@ export const WorkflowInfoBox = ({ workflow }) => {
     div({ 'data-testid': 'timing-container' }, [
       div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Timing:'])]),
       div({}, [
-        div({}, [span({ style: { fontWeight: 'bold' } }, ['Start: ']), span({}, [workflowStart])]),
-        div({}, [span({ style: { fontWeight: 'bold' } }, ['End: ']), span({}, [workflowEnd])])
+        div({}, [span({ 'data-testid': 'workflow-start', style: { fontWeight: 'bold' } }, ['Start: ']), span({}, [workflowStart])]),
+        div({}, [span({ 'data-testid': 'workflow-end', style: { fontWeight: 'bold' } }, ['End: ']), span({}, [workflowEnd])])
       ])
     ]),
     div({ 'data-testid': 'status-container', style: {} }, [

--- a/src/components/WorkflowInfoBox.js
+++ b/src/components/WorkflowInfoBox.js
@@ -17,37 +17,46 @@ export const WorkflowInfoBox = ({ workflow }) => {
 
   const [showWDLModal, setShowWDLModal] = useState(false)
 
-  return div({
-    style: {
-      paddingTop: '0.25em',
-      paddingBottom: '0.25em',
-      lineHeight: '24px',
-      display: 'flex',
-      justifyContent: 'space-between',
-      width: '60%'
-    }
-  }, [
-    div({ 'data-testid': 'timing-container' }, [
-      div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Timing:'])]),
-      div({}, [
-        div({}, [span({ 'data-testid': 'workflow-start', style: { fontWeight: 'bold' } }, ['Start: ']), span({}, [workflowStart])]),
-        div({}, [span({ 'data-testid': 'workflow-end', style: { fontWeight: 'bold' } }, ['End: ']), span({}, [workflowEnd])])
-      ])
-    ]),
-    div({ 'data-testid': 'status-container', style: {} }, [
-      div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Status:'])]),
-      div({}, [
-        div({ style: { lineHeight: '24px', marginTop: '0.5rem' } }, [
-          makeStatusLine(style => collapseStatus(status).icon(style), status)
+  return div(
+    {
+      style: {
+        paddingTop: '0.25em',
+        paddingBottom: '0.25em',
+        lineHeight: '24px',
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: '60%'
+      }
+    },
+    [
+      div({ 'data-testid': 'timing-container' }, [
+        div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Timing:'])]),
+        div({}, [
+          div({ 'data-testid': 'workflow-start-container' }, [span({ style: { fontWeight: 'bold' } }, ['Start: ']), span({}, [workflowStart])]),
+          div({ 'data-testid': 'workflow-end-container' }, [span({ style: { fontWeight: 'bold' } }, ['End: ']), span({}, [workflowEnd])])
         ])
-      ])
-    ]),
-    div({ 'data-testid': 'wdl-container', style: { } }, [
-      div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Script:'])]),
-      div({}, [h(Link, { onClick: () => { setShowWDLModal(true) } }, [
-        icon('fileAlt', { size: 18 }), ' View Workflow Script'
-      ])])
-    ]),
-    showWDLModal && h(ViewWorkflowScriptModal, { workflowScript, onDismiss: () => setShowWDLModal(false) }, [])
-  ])
+      ]),
+      div({ 'data-testid': 'status-container', style: {} }, [
+        div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Status:'])]),
+        div({}, [
+          div({ style: { lineHeight: '24px', marginTop: '0.5rem' } }, [makeStatusLine(style => collapseStatus(status).icon(style), status)])
+        ])
+      ]),
+      div({ 'data-testid': 'wdl-container', style: {} }, [
+        div({}, [span({ style: { fontWeight: 'bold', fontSize: 16 } }, ['Workflow Script:'])]),
+        div({}, [
+          h(
+            Link,
+            {
+              onClick: () => {
+                setShowWDLModal(true)
+              }
+            },
+            [icon('fileAlt', { size: 18 }), ' View Workflow Script']
+          )
+        ])
+      ]),
+      showWDLModal && h(ViewWorkflowScriptModal, { workflowScript, onDismiss: () => setShowWDLModal(false) }, [])
+    ]
+  )
 }

--- a/src/fixtures/test-child-workflow.js
+++ b/src/fixtures/test-child-workflow.js
@@ -1,0 +1,512 @@
+export const metadata = {
+  workflowName: 'wf_scattering',
+  rootWorkflowId: 'be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  calls: {
+    'wf_scattering.scatteringHello': [
+      {
+        stdout:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stdout',
+        shardIndex: 0,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:27.947Z',
+        start: '2023-06-18T15:49:41.465Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stderr',
+        callRoot:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:50:27.032Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:27.947Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.465Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:41.466Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.347Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.456Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.347Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.466Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.456Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:27.032Z'
+          }
+        ]
+      },
+      {
+        stdout:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stdout',
+        shardIndex: 1,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:17.965Z',
+        start: '2023-06-18T15:49:41.463Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stderr',
+        callRoot:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.346Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:17.367Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:17.967Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.463Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:41.464Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.464Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.346Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.456Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.456Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:17.367Z'
+          }
+        ]
+      },
+      {
+        stdout:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stdout',
+        shardIndex: 2,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:21.947Z',
+        start: '2023-06-18T15:49:41.464Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stderr',
+        callRoot:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:43.455Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:20.982Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.465Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.464Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:41.465Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.346Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:20.982Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:21.946Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.346Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.455Z'
+          }
+        ]
+      }
+    ],
+    'wf_scattering.scatteringGoodbye': [
+      {
+        stdout:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stdout',
+        shardIndex: 0,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:27.948Z',
+        start: '2023-06-18T15:49:41.465Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stderr',
+        callRoot:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.346Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.465Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.346Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.455Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.455Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:27.802Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:27.802Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:27.947Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.465Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:41.465Z'
+          }
+        ]
+      },
+      {
+        stdout:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stdout',
+        shardIndex: 1,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:25.944Z',
+        start: '2023-06-18T15:49:41.464Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stderr',
+        callRoot:
+          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.376Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.464Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:41.464Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.454Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:25.051Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.376Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.454Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:25.051Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:25.944Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:41.464Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          }
+        ]
+      }
+    ]
+  },
+  workflowRoot: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  status: 'Failed',
+  parentWorkflowId: 'be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  end: '2023-06-18T15:50:28.385Z',
+  start: '2023-06-18T15:49:37.332Z',
+  id: '97967c22-bcc1-4946-b9c7-d4375f8b3070',
+  inputs: {}
+}

--- a/src/fixtures/test-parent-workflow.js
+++ b/src/fixtures/test-parent-workflow.js
@@ -1,0 +1,521 @@
+export const metadata = {
+  workflowName: 'main_workflow',
+  workflowProcessingEvents: [
+    {
+      cromwellId: 'cromid-a914842',
+      description: 'PickedUp',
+      timestamp: '2023-06-18T15:49:34.661Z',
+      cromwellVersion: '86-17efd59-SNAP'
+    },
+    {
+      cromwellId: 'cromid-a914842',
+      description: 'Finished',
+      timestamp: '2023-06-18T15:50:33.421Z',
+      cromwellVersion: '86-17efd59-SNAP'
+    }
+  ],
+  actualWorkflowLanguageVersion: '1.0',
+  submittedFiles: {
+    workflow:
+      // eslint-disable-next-line no-template-curly-in-string
+      'version 1.0\n\nimport "testworkflow.wdl" as sub\n\ntask start {\n  command {\n    echo "${2/0}"\n  }\n  output {\n    String out = read_string(stdout())\n  }\n}\n\ntask done {\n  command {\n    echo "${2/0}"\n  }\n  output {\n    String out = read_string(stdout())\n  }\n}\n\nworkflow main_workflow {\n  call start\n  call sub.wf_scattering\n  call done\n}\n',
+    workflowTypeVersion: '1.0',
+    options: '{\n\n}',
+    inputs: '{}',
+    workflowType: 'WDL',
+    root: '',
+    workflowUrl: '',
+    labels: '{}'
+  },
+  calls: {
+    'main_workflow.done': [
+      {
+        stdout: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-done/execution/stdout',
+        shardIndex: -1,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:27.947Z',
+        start: '2023-06-18T15:49:37.278Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-done/execution/stderr',
+        callRoot: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-done',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:37.345Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.301Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:37.345Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.454Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:27.172Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.346Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:27.172Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:27.947Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.346Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.454Z'
+          }
+        ]
+      }
+    ],
+    'main_workflow.start': [
+      {
+        stdout: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-start/execution/stdout',
+        shardIndex: -1,
+        runtimeAttributes: {
+          maxRetries: '0',
+          failOnStderr: 'false',
+          continueOnReturnCode: '0'
+        },
+        callCaching: {
+          allowResultReuse: false,
+          hashes: {
+            'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+            'runtime attribute': {
+              docker: 'N/A',
+              continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+              failOnStderr: '68934A3E9455FA72420237EB05902327'
+            },
+            'output expression': {
+              'String out': '0183144CF6617D5341681C6B2F756046'
+            },
+            'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+            'backend name': '509820290D57F333403F490DDE7316F4',
+            'command template': 'E80AE16736B864DC65CEA153382F11F7'
+          },
+          effectiveCallCachingMode: 'ReadAndWriteCache',
+          hit: false,
+          result: 'Cache Miss'
+        },
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [],
+                        message: 'Divide by zero error: 2 / WomInteger(0)'
+                      }
+                    ],
+                    message: 'Error(s)'
+                  }
+                ],
+                message: 'Failed command instantiation'
+              }
+            ],
+            message: 'java.lang.Exception: Failed command instantiation'
+          }
+        ],
+        backend: 'Local',
+        end: '2023-06-18T15:50:19.945Z',
+        start: '2023-06-18T15:49:37.282Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        stderr: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-start/execution/stderr',
+        callRoot: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-start',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:43.356Z',
+            description: 'CallCacheReading',
+            endTime: '2023-06-18T15:49:43.456Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.301Z',
+            description: 'Pending',
+            endTime: '2023-06-18T15:49:37.345Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.345Z',
+            description: 'RequestingExecutionToken',
+            endTime: '2023-06-18T15:49:43.170Z'
+          },
+          {
+            startTime: '2023-06-18T15:50:19.820Z',
+            description: 'UpdatingJobStore',
+            endTime: '2023-06-18T15:50:19.945Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.456Z',
+            description: 'RunningJob',
+            endTime: '2023-06-18T15:50:19.820Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.180Z',
+            description: 'PreparingJob',
+            endTime: '2023-06-18T15:49:43.356Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:43.170Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:43.180Z'
+          }
+        ]
+      }
+    ],
+    'main_workflow.wf_scattering': [
+      {
+        shardIndex: -1,
+        inputs: {},
+        failures: [
+          {
+            causedBy: [
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [
+                          {
+                            causedBy: [],
+                            message: 'Divide by zero error: 2 / WomInteger(0)'
+                          }
+                        ],
+                        message: 'Error(s)'
+                      }
+                    ],
+                    message: 'Failed command instantiation'
+                  }
+                ],
+                message: 'java.lang.Exception: Failed command instantiation'
+              },
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [
+                          {
+                            causedBy: [],
+                            message: 'Divide by zero error: 2 / WomInteger(0)'
+                          }
+                        ],
+                        message: 'Error(s)'
+                      }
+                    ],
+                    message: 'Failed command instantiation'
+                  }
+                ],
+                message: 'java.lang.Exception: Failed command instantiation'
+              },
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [
+                          {
+                            causedBy: [],
+                            message: 'Divide by zero error: 2 / WomInteger(0)'
+                          }
+                        ],
+                        message: 'Error(s)'
+                      }
+                    ],
+                    message: 'Failed command instantiation'
+                  }
+                ],
+                message: 'java.lang.Exception: Failed command instantiation'
+              },
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [
+                          {
+                            causedBy: [],
+                            message: 'Divide by zero error: 2 / WomInteger(0)'
+                          }
+                        ],
+                        message: 'Error(s)'
+                      }
+                    ],
+                    message: 'Failed command instantiation'
+                  }
+                ],
+                message: 'java.lang.Exception: Failed command instantiation'
+              },
+              {
+                causedBy: [
+                  {
+                    causedBy: [
+                      {
+                        causedBy: [
+                          {
+                            causedBy: [],
+                            message: 'Divide by zero error: 2 / WomInteger(0)'
+                          }
+                        ],
+                        message: 'Error(s)'
+                      }
+                    ],
+                    message: 'Failed command instantiation'
+                  }
+                ],
+                message: 'java.lang.Exception: Failed command instantiation'
+              }
+            ],
+            message: 'Workflow failed'
+          }
+        ],
+        end: '2023-06-18T15:50:32.922Z',
+        retryableFailure: false,
+        executionStatus: 'Failed',
+        attempt: 1,
+        executionEvents: [
+          {
+            startTime: '2023-06-18T15:49:37.291Z',
+            description: 'SubWorkflowPendingState',
+            endTime: '2023-06-18T15:49:37.314Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.314Z',
+            description: 'WaitingForValueStore',
+            endTime: '2023-06-18T15:49:37.332Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.345Z',
+            description: 'SubWorkflowRunningState',
+            endTime: '2023-06-18T15:50:28.385Z'
+          },
+          {
+            startTime: '2023-06-18T15:49:37.332Z',
+            description: 'SubWorkflowPreparingState',
+            endTime: '2023-06-18T15:49:37.345Z'
+          }
+        ],
+        start: '2023-06-18T15:49:37.284Z',
+        subWorkflowId: '97967c22-bcc1-4946-b9c7-d4375f8b3070'
+      }
+    ]
+  },
+  outputs: {},
+  workflowRoot: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  actualWorkflowLanguage: 'WDL',
+  status: 'Failed',
+  failures: [
+    {
+      causedBy: [
+        {
+          causedBy: [
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [],
+                      message: 'Divide by zero error: 2 / WomInteger(0)'
+                    }
+                  ],
+                  message: 'Error(s)'
+                }
+              ],
+              message: 'Failed command instantiation'
+            }
+          ],
+          message: 'java.lang.Exception: Failed command instantiation'
+        },
+        {
+          causedBy: [
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [],
+                      message: 'Divide by zero error: 2 / WomInteger(0)'
+                    }
+                  ],
+                  message: 'Error(s)'
+                }
+              ],
+              message: 'Failed command instantiation'
+            }
+          ],
+          message: 'java.lang.Exception: Failed command instantiation'
+        },
+        {
+          causedBy: [
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [
+                        {
+                          causedBy: [],
+                          message: 'Divide by zero error: 2 / WomInteger(0)'
+                        }
+                      ],
+                      message: 'Error(s)'
+                    }
+                  ],
+                  message: 'Failed command instantiation'
+                }
+              ],
+              message: 'java.lang.Exception: Failed command instantiation'
+            },
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [
+                        {
+                          causedBy: [],
+                          message: 'Divide by zero error: 2 / WomInteger(0)'
+                        }
+                      ],
+                      message: 'Error(s)'
+                    }
+                  ],
+                  message: 'Failed command instantiation'
+                }
+              ],
+              message: 'java.lang.Exception: Failed command instantiation'
+            },
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [
+                        {
+                          causedBy: [],
+                          message: 'Divide by zero error: 2 / WomInteger(0)'
+                        }
+                      ],
+                      message: 'Error(s)'
+                    }
+                  ],
+                  message: 'Failed command instantiation'
+                }
+              ],
+              message: 'java.lang.Exception: Failed command instantiation'
+            },
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [
+                        {
+                          causedBy: [],
+                          message: 'Divide by zero error: 2 / WomInteger(0)'
+                        }
+                      ],
+                      message: 'Error(s)'
+                    }
+                  ],
+                  message: 'Failed command instantiation'
+                }
+              ],
+              message: 'java.lang.Exception: Failed command instantiation'
+            },
+            {
+              causedBy: [
+                {
+                  causedBy: [
+                    {
+                      causedBy: [
+                        {
+                          causedBy: [],
+                          message: 'Divide by zero error: 2 / WomInteger(0)'
+                        }
+                      ],
+                      message: 'Error(s)'
+                    }
+                  ],
+                  message: 'Failed command instantiation'
+                }
+              ],
+              message: 'java.lang.Exception: Failed command instantiation'
+            }
+          ],
+          message: 'Workflow failed'
+        }
+      ],
+      message: 'Workflow failed'
+    }
+  ],
+  end: '2023-06-18T15:50:33.420Z',
+  start: '2023-06-18T15:49:34.753Z',
+  id: 'be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  inputs: {},
+  labels: {
+    'cromwell-workflow-id': 'cromwell-be48c79d-f8e8-4a0a-bed4-787a30a60305'
+  },
+  submission: '2023-06-18T15:49:33.770Z'
+}

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -90,9 +90,9 @@ export const RunDetails = ({ submissionId, workflowId }) => {
   ], [])
   const excludeKey = useMemo(() => [], [])
   const fetchMetadata = useCallback(workflowId => Ajax(signal).Cromwell.workflows(workflowId).metadata({ includeKey, excludeKey }), [includeKey, excludeKey, signal])
-  const loadWorkflow = useCallback(async (workflowId, updateBreadcrumb = undefined) => {
+  const loadWorkflow = useCallback(async (workflowId, updateWorkflowPath = undefined) => {
     const metadata = await fetchMetadata(workflowId)
-    isNil(updateBreadcrumb) && setWorkflow(metadata)
+    isNil(updateWorkflowPath) && setWorkflow(metadata)
     if (!isEmpty(metadata?.calls)) {
       const formattedTableData = generateCallTableData(metadata.calls)
       setTableData(formattedTableData)
@@ -100,7 +100,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
         stateRefreshTimer.current = setTimeout(loadWorkflow, 60000)
       }
     }
-    !isNil(updateBreadcrumb) && updateBreadcrumb()
+    !isNil(updateWorkflowPath) && updateWorkflowPath()
   }, [fetchMetadata])
 
   /*

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -21,7 +21,6 @@ import { elements } from 'src/libs/style'
 import { cond, newTabLinkProps } from 'src/libs/utils'
 import CallTable from 'src/pages/workspaces/workspace/jobHistory/CallTable'
 
-
 // Filter function that only displays rows based on task name search parameters
 // NOTE: the viewable call should have the task name stored on the call instance itself, should be done via pre-processing step
 export const taskNameFilterFn = searchTerm => filter(call => call?.taskName?.includes(searchTerm))
@@ -41,7 +40,6 @@ export const generateCallTableData = calls => {
     return Object.assign(additionalData, lastCall)
   })
 }
-
 
 export const RunDetails = ({ submissionId, workflowId }) => {
   /*
@@ -90,8 +88,10 @@ export const RunDetails = ({ submissionId, workflowId }) => {
   ], [])
   const excludeKey = useMemo(() => [], [])
   const fetchMetadata = useCallback(workflowId => Ajax(signal).Cromwell.workflows(workflowId).metadata({ includeKey, excludeKey }), [includeKey, excludeKey, signal])
+
   const loadWorkflow = useCallback(async (workflowId, updateWorkflowPath = undefined) => {
     const metadata = await fetchMetadata(workflowId)
+    const { workflowName } = metadata
     isNil(updateWorkflowPath) && setWorkflow(metadata)
     if (!isEmpty(metadata?.calls)) {
       const formattedTableData = generateCallTableData(metadata.calls)
@@ -100,7 +100,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
         stateRefreshTimer.current = setTimeout(loadWorkflow, 60000)
       }
     }
-    !isNil(updateWorkflowPath) && updateWorkflowPath()
+    !isNil(updateWorkflowPath) && updateWorkflowPath(workflowId, workflowName)
   }, [fetchMetadata])
 
   /*
@@ -187,7 +187,8 @@ export const RunDetails = ({ submissionId, workflowId }) => {
               showLogModal,
               showTaskDataModal,
               tableData,
-              workflowName: workflow?.workflowName
+              workflowName: workflow?.workflowName,
+              workflowId: workflow?.id
             })
           ]
         ),

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -1,5 +1,5 @@
 
-import { cloneDeep, filter, includes, isEmpty } from 'lodash/fp'
+import { cloneDeep, filter, includes, isEmpty, isNil } from 'lodash/fp'
 import { Fragment, useCallback, useMemo, useRef, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { Link, Navbar } from 'src/components/common'
@@ -36,11 +36,12 @@ export const generateCallTableData = calls => {
     //helper construct that assigns task name and status to the call object for easy access within the call tabler renderer
     const additionalData = {
       taskName,
-      statusObj: collapseCromwellStatus(lastCall.executionStatus, lastCall.backendStatus)
+      statusObj: collapseCromwellStatus(lastCall.executionStatus, lastCall.backendStatus),
     }
     return Object.assign(additionalData, lastCall)
   })
 }
+
 
 export const RunDetails = ({ submissionId, workflowId }) => {
   /*
@@ -72,43 +73,46 @@ export const RunDetails = ({ submissionId, workflowId }) => {
     setShowTaskData(true)
   }, [])
 
+  const includeKey = useMemo(() => [
+    'backendStatus',
+    'executionStatus',
+    'shardIndex',
+    // 'outputs', //not sure if I need this yet
+    // 'inputs', //not sure if I need this yet
+    'jobId',
+    'start',
+    'end',
+    'stderr',
+    'stdout',
+    'attempt',
+    'subWorkflowId' //needed for task type column
+    // 'subWorkflowMetadata' //may need this later
+  ], [])
+  const excludeKey = useMemo(() => [], [])
+  const fetchMetadata = useCallback(workflowId => Ajax(signal).Cromwell.workflows(workflowId).metadata({ includeKey, excludeKey }), [includeKey, excludeKey, signal])
+  const loadWorkflow = useCallback(async (workflowId, updateBreadcrumb = undefined) => {
+    const metadata = await fetchMetadata(workflowId)
+    isNil(updateBreadcrumb) && setWorkflow(metadata)
+    if (!isEmpty(metadata?.calls)) {
+      const formattedTableData = generateCallTableData(metadata.calls)
+      setTableData(formattedTableData)
+      if (includes(collapseStatus(metadata.status), [statusType.running, statusType.submitted])) {
+        stateRefreshTimer.current = setTimeout(loadWorkflow, 60000)
+      }
+    }
+    !isNil(updateBreadcrumb) && updateBreadcrumb()
+  }, [fetchMetadata])
+
   /*
    * Data fetchers
    */
   useOnMount(() => {
-    const loadWorkflow = async () => {
-      const includeKey = [
-        'backendStatus',
-        'executionStatus',
-        'shardIndex',
-        // 'outputs', //not sure if I need this yet
-        // 'inputs', //not sure if I need this yet
-        'jobId',
-        'start',
-        'end',
-        'stderr',
-        'stdout',
-        'attempt',
-        'subWorkflowId' //needed for task type column
-        // 'subWorkflowMetadata' //may need this later
-      ]
-      const excludeKey = []
-      const metadata = await Ajax(signal).Cromwell.workflows(workflowId).metadata({ includeKey, excludeKey })
-      setWorkflow(metadata)
-      if (!isEmpty(metadata?.calls)) {
-        const formattedTableData = generateCallTableData(metadata.calls)
-        setTableData(formattedTableData)
-        if (includes(collapseStatus(metadata.status), [statusType.running, statusType.submitted])) {
-          stateRefreshTimer.current = setTimeout(loadWorkflow, 60000)
-        }
-      }
-    }
     const fetchSasToken = async () => {
       const sasToken = await Ajax(signal).WorkspaceManager.getSASToken()
       setSasToken(sasToken)
     }
     fetchSasToken()
-    loadWorkflow()
+    loadWorkflow(workflowId)
     return () => {
       clearTimeout(stateRefreshTimer.current)
     }
@@ -176,11 +180,14 @@ export const RunDetails = ({ submissionId, workflowId }) => {
           },
           [
             h(CallTable, {
+              enableExplorer: workflow?.status.toLocaleLowerCase() === 'succeeded',
+              loadWorkflow,
               defaultFailedFilter: workflow?.status.toLocaleLowerCase().includes('failed'),
               isRendered: !isEmpty(tableData),
               showLogModal,
               showTaskDataModal,
-              tableData
+              tableData,
+              workflowName: workflow?.workflowName
             })
           ]
         ),

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -35,7 +35,7 @@ export const generateCallTableData = calls => {
     //helper construct that assigns task name and status to the call object for easy access within the call tabler renderer
     const additionalData = {
       taskName,
-      statusObj: collapseCromwellStatus(lastCall.executionStatus, lastCall.backendStatus),
+      statusObj: collapseCromwellStatus(lastCall.executionStatus, lastCall.backendStatus)
     }
     return Object.assign(additionalData, lastCall)
   })

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -129,10 +129,14 @@ describe('RunDetails - render smoke test', () => {
   it('shows the workflow timing', async () => {
     render(h(RunDetails, runDetailsProps))
     await waitFor(() => {
-      const startTime = screen.getByTestId('workflow-start')
+      const startTime = screen.getByTestId('workflow-start-container')
       expect(startTime).toBeDefined
-      const endTime = screen.getByTestId('workflow-end')
+      const endTime = screen.getByTestId('workflow-end-container')
       expect(endTime).toBeDefined
+      const formattedStart = makeCompleteDate(runDetailsMetadata.start)
+      const formattedEnd = makeCompleteDate(runDetailsMetadata.end)
+      expect(startTime.textContent).toContain(formattedStart)
+      expect(endTime.textContent).toContain(formattedEnd)
     })
   })
 

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -10,6 +10,8 @@ import { Ajax } from 'src/libs/ajax'
 import * as configStore from 'src/libs/config'
 import { makeCompleteDate } from 'src/libs/utils'
 
+import { metadata as childMetadata } from '../fixtures/test-child-workflow'
+import { metadata as parentMetadata } from '../fixtures/test-parent-workflow'
 import { metadata as runDetailsMetadata } from '../fixtures/test-workflow'
 import { RunDetails } from './RunDetails'
 
@@ -62,6 +64,25 @@ const mockObj = {
   }
 }
 
+const subworkflowCromwellAjaxMock = (parentOverride = {}) => {
+  const modifiedParentMetadata = Object.assign({}, parentMetadata, parentOverride)
+  return {
+    Cromwell: {
+      workflows: id => {
+        return {
+          metadata: () => {
+            const workflowMap = {
+              [parentMetadata.id]: modifiedParentMetadata,
+              [childMetadata.id]: childMetadata
+            }
+            return workflowMap[id]
+          }
+        }
+      }
+    }
+  }
+}
+
 beforeEach(() => {
   Ajax.mockImplementation(() => {
     return mockObj
@@ -108,9 +129,9 @@ describe('RunDetails - render smoke test', () => {
   it('shows the workflow timing', async () => {
     render(h(RunDetails, runDetailsProps))
     await waitFor(() => {
-      const startTime = screen.getByText(makeCompleteDate(runDetailsMetadata.start))
+      const startTime = screen.getByTestId('workflow-start')
       expect(startTime).toBeDefined
-      const endTime = screen.getByText(makeCompleteDate(runDetailsMetadata.end))
+      const endTime = screen.getByTestId('workflow-end')
       expect(endTime).toBeDefined
     })
   })
@@ -187,14 +208,14 @@ describe('RunDetails - render smoke test', () => {
         expect(inputs).toBeDefined
         const outputs = within(row).getByTestId('outputs-modal-link')
         expect(outputs).toBeDefined
-        //Following checks are looking for the taget text on the cell and on the tooltip elements
+        //Checking row text content for dates since querying by formatted date doesn't seem to work
         const statusObj = collapseCromwellStatus(executionStatus, backendStatus)
         const status = within(row).queryAllByText(statusObj.label())
         expect(status.length).toEqual(2)
-        const startTime = within(row).queryAllByText(makeCompleteDate(start))
-        expect(startTime.length).toEqual(2)
-        const endTime = within(row).queryAllByText(makeCompleteDate(end))
-        expect(endTime.length).toEqual(2)
+        const targetStartText = makeCompleteDate(start)
+        const targetEndText = makeCompleteDate(end)
+        expect(row.textContent).toContain(targetStartText)
+        expect(row.textContent).toContain(targetEndText)
       })
     })
   })
@@ -230,10 +251,10 @@ describe('RunDetails - render smoke test', () => {
       expect(taskName).toBeDefined
       const failedStatus = within(targetRow).queryAllByText('Failed')
       expect(failedStatus.length).toEqual(2)
-      const startTime = within(targetRow).queryAllByText(makeCompleteDate(start))
-      expect(startTime.length).toEqual(2)
-      const endTime = within(targetRow).queryAllByText(makeCompleteDate(end))
-      expect(endTime.length).toEqual(2)
+      const targetStartText = makeCompleteDate(start)
+      const targetEndText = makeCompleteDate(end)
+      expect(targetRow.textContent).toContain(targetStartText)
+      expect(targetRow.textContent).toContain(targetEndText)
       const stdout = within(targetRow).getByText('stdout')
       expect(stdout).toBeDefined
       const stderr = within(targetRow).getByText('stderr')
@@ -426,5 +447,93 @@ describe('RunDetails - render smoke test', () => {
     expect(appendedPublic).toEqual(publicURI)
     expect(appendedPrivate).toEqual(`${privateURI}?${mockSAS}`)
   })
-})
 
+  it('renders the workflow path above the table for successful workflows', async () => {
+    render(h(RunDetails, runDetailsProps))
+    await waitFor(() => {
+      const workflowPath = screen.getByTestId('workflow-path')
+      expect(workflowPath).toBeDefined
+      const workflowPathText = within(workflowPath).getByText(runDetailsMetadata.workflowName)
+      expect(workflowPathText).toBeDefined
+    })
+  })
+
+  it('shows the "View sub-workflow" button for sub-workflows', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    const altRunDetailsProps = Object.assign({}, runDetailsProps, { workflowId: parentMetadata.id })
+    Ajax.mockImplementation(() => Object.assign({}, altMockObj, subworkflowCromwellAjaxMock({ status: 'Succeeded' })))
+    render(h(RunDetails, altRunDetailsProps))
+    await waitFor(() => {
+      const childId = childMetadata.id
+      const table = screen.getByTestId('call-table-container')
+      const subworkflowButton = within(table).getByTestId(`view-subworkflow-${childId}`)
+      expect(subworkflowButton).toBeDefined
+    })
+  })
+
+  it('updates the workflow path when the "View sub-workflow" button is clicked', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    const altRunDetailsProps = Object.assign({}, runDetailsProps, { workflowId: parentMetadata.id })
+    Ajax.mockImplementation(() => Object.assign({}, altMockObj, subworkflowCromwellAjaxMock({ status: 'Succeeded' })))
+    const user = userEvent.setup()
+    render(h(RunDetails, altRunDetailsProps))
+    await waitFor(async () => {
+      const childId = childMetadata.id
+      const table = screen.getByTestId('call-table-container')
+      const subworkflowButton = within(table).getByTestId(`view-subworkflow-${childId}`)
+      expect(subworkflowButton).toBeDefined
+      await user.click(subworkflowButton)
+      const workflowPath = screen.getByTestId('workflow-path')
+      expect(workflowPath).toBeDefined
+      const childIdText = within(workflowPath).getByText(childMetadata.workflowName)
+      expect(childIdText).toBeDefined
+    })
+  })
+
+  it('updates the table to show the sub-workflow calls when the "View sub-workflow" button is clicked', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    const altRunDetailsProps = Object.assign({}, runDetailsProps, { workflowId: parentMetadata.id })
+    Ajax.mockImplementation(() => Object.assign({}, altMockObj, subworkflowCromwellAjaxMock({ status: 'Succeeded' })))
+    const user = userEvent.setup()
+    render(h(RunDetails, altRunDetailsProps))
+    await waitFor(async () => {
+      const childId = childMetadata.id
+      const table = screen.getByTestId('call-table-container')
+      const subworkflowButton = within(table).getByTestId(`view-subworkflow-${childId}`)
+      await user.click(subworkflowButton)
+      const updatedTable = screen.getByTestId('call-table-container')
+      const subWorkflowTaskNames = Object.keys(childMetadata.calls)
+      subWorkflowTaskNames.forEach(taskName => {
+        const taskNameText = within(updatedTable).getByText(taskName)
+        expect(taskNameText).toBeDefined
+      })
+    })
+  })
+
+  it('updates the workflow path and the table if the user clicks on a workflow id within the workflow path', async () => {
+    const altMockObj = cloneDeep(mockObj)
+    const altRunDetailsProps = Object.assign({}, runDetailsProps, { workflowId: parentMetadata.id })
+    Ajax.mockImplementation(() => Object.assign({}, altMockObj, subworkflowCromwellAjaxMock({ status: 'Succeeded' })))
+    const user = userEvent.setup()
+    render(h(RunDetails, altRunDetailsProps))
+    await waitFor(async () => {
+      const childId = childMetadata.id
+      const table = screen.getByTestId('call-table-container')
+      const subworkflowButton = within(table).getByTestId(`view-subworkflow-${childId}`)
+      await user.click(subworkflowButton)
+      const workflowPath = screen.getByTestId('workflow-path')
+      const targetIdPath = within(workflowPath).getByText(parentMetadata.workflowName)
+      await user.click(targetIdPath)
+      const updatedTable = screen.getByTestId('call-table-container')
+      const updatedPath = screen.getByTestId('workflow-path')
+      const parentWorkflowName = within(updatedPath).getByText(parentMetadata.workflowName)
+      expect(parentWorkflowName).toBeDefined
+      expect(screen.queryByText(childMetadata.workflowName)).not.toBeInTheDocument
+      const parentTaskNames = Object.keys(parentMetadata.calls)
+      parentTaskNames.forEach(taskName => {
+        const taskNameText = within(updatedTable).getByText(taskName)
+        expect(taskNameText).toBeDefined
+      })
+    })
+  })
+})

--- a/src/pages/workspaces/Breadcrumb.js
+++ b/src/pages/workspaces/Breadcrumb.js
@@ -1,0 +1,4 @@
+export default function Breadcrumnb() {
+  const [path, setPath] = []
+
+}

--- a/src/pages/workspaces/Breadcrumb.js
+++ b/src/pages/workspaces/Breadcrumb.js
@@ -1,4 +1,0 @@
-export default function Breadcrumnb() {
-  const [path, setPath] = []
-
-}

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -177,7 +177,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
         h(SearchBar, { filterFn })
       ])
     ]),
-    h(WorkflowBreadcrumb, { workflowPath, loadWorkflow, updateWorkflowPath }),
+    h(WorkflowBreadcrumb, { isRendered: enableExplorer, workflowPath, loadWorkflow, updateWorkflowPath }),
     h(AutoSizer, { disableHeight: true }, [
       ({ width }) => h(FlexTable, {
         'aria-label': 'call table',

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -78,9 +78,10 @@ const SearchBar = ({ filterFn }) => {
 ///////WORKFLOW BREADCRUMB SUB-COMPONENT///////////////////////
 const WorkflowBreadcrumb = ({ workflowPath, loadWorkflow, updateWorkflowPath }) => {
   const workflowPathRender = workflowPath.map((workflow, index) => {
+    const { id, workflowName } = workflow
     const isLast = index === workflowPath.length - 1
-    return span({ key: `${workflow}-breadcrumb`, style: { marginRight: '5px' } }, [
-      isLast ? span([`${workflow}`]) : span({ style: { cursor: 'pointer' }, onClick: () => loadWorkflow(workflowPath.slice(0, index + 1), updateWorkflowPath) }, [`${workflow}`]),
+    return span({ key: `${id}-breadcrumb`, style: { marginRight: '5px' } }, [
+      isLast ? span([workflowName]) : h(Link, { style: { cursor: 'pointer' }, onClick: () => loadWorkflow(id, updateWorkflowPath) }, [workflowName]),
       !isLast && span(' > ')
     ])
   })
@@ -88,13 +89,12 @@ const WorkflowBreadcrumb = ({ workflowPath, loadWorkflow, updateWorkflowPath }) 
 }
 
 ////////CALL TABLE///////////////////////
-const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal, loadWorkflow, enableExplorer = false, initWorkflow }) => {
-  const {id, workflowName} = initWorkflow
+const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal, loadWorkflow, enableExplorer = false, workflowName, workflowId }) => {
   const [sort, setSort] = useState({ field: 'index', direction: 'asc' })
   const [statusFilter, setStatusFilter] = useState([])
   const [filteredCallObjects, setFilteredCallObjects] = useState([])
   //NOTE: workflowPath is used to load the workflow in the explorer, implement after the table update is confirmed to be working
-  const [workflowPath, setWorkflowPath] = useState([{id, workflowName}])
+  const [workflowPath, setWorkflowPath] = useState([{id: workflowId, workflowName}])
 
   useEffect(() => {
     if (defaultFailedFilter) {
@@ -126,7 +126,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
 
   const updateWorkflowPath = useCallback((id, workflowName) => {
     const currentIndex = workflowPath.findIndex(workflow => workflow.id === id)
-    if(!_.isEmpty(currentIndex)) {
+    if(currentIndex !== -1) {
       setWorkflowPath(workflowPath.slice(0, currentIndex + 1))
     } else {
       setWorkflowPath([...workflowPath, { id, workflowName }])

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { div, h, input, label, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Link, Select } from 'src/components/common'
@@ -75,13 +75,26 @@ const SearchBar = ({ filterFn }) => {
   )
 }
 
+///////WORKFLOW BREADCRUMB SUB-COMPONENT///////////////////////
+const WorkflowBreadcrumb = ({ workflowPath, loadWorkflow, updateWorkflowPath }) => {
+  const workflowPathRender = workflowPath.map((workflow, index) => {
+    const isLast = index === workflowPath.length - 1
+    return span({ key: `${workflow}-breadcrumb`, style: { marginRight: '5px' } }, [
+      isLast ? span([`${workflow}`]) : span({ style: { cursor: 'pointer' }, onClick: () => loadWorkflow(workflowPath.slice(0, index + 1), updateWorkflowPath) }, [`${workflow}`]),
+      !isLast && span(' > ')
+    ])
+  })
+  return div({ style: { marginBottom: '10px' } }, [workflowPathRender])
+}
+
 ////////CALL TABLE///////////////////////
-const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal, loadWorkflow, enableExplorer = false, workflowName }) => {
+const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal, loadWorkflow, enableExplorer = false, initWorkflow }) => {
+  const {id, workflowName} = initWorkflow
   const [sort, setSort] = useState({ field: 'index', direction: 'asc' })
   const [statusFilter, setStatusFilter] = useState([])
   const [filteredCallObjects, setFilteredCallObjects] = useState([])
   //NOTE: workflowPath is used to load the workflow in the explorer, implement after the table update is confirmed to be working
-  const [workflowPath, setWorkflowPath] = useState([workflowName])
+  const [workflowPath, setWorkflowPath] = useState([{id, workflowName}])
 
   useEffect(() => {
     if (defaultFailedFilter) {
@@ -110,6 +123,15 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
     })
     return statusSet
   }, [tableData])
+
+  const updateWorkflowPath = useCallback((id, workflowName) => {
+    const currentIndex = workflowPath.findIndex(workflow => workflow.id === id)
+    if(!_.isEmpty(currentIndex)) {
+      setWorkflowPath(workflowPath.slice(0, currentIndex + 1))
+    } else {
+      setWorkflowPath([...workflowPath, { id, workflowName }])
+    }
+  }, [workflowPath])
 
   return div([
     label({
@@ -155,7 +177,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
         h(SearchBar, { filterFn })
       ])
     ]),
-
+    h(WorkflowBreadcrumb, { workflowPath, loadWorkflow, updateWorkflowPath }),
     h(AutoSizer, { disableHeight: true }, [
       ({ width }) => h(FlexTable, {
         'aria-label': 'call table',
@@ -241,8 +263,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
                 [h(Link, {
                   'data-testid': `view-subworkflow-${subWorkflowId}-link`,
                   onClick: () => {
-                    //NOTE: defined callback function to execute breadcrumb update here and pass it into loadWorkflow
-                    loadWorkflow(subWorkflowId)
+                    loadWorkflow(subWorkflowId, updateWorkflowPath)
                   }
                 }, ['View subworkflow'])] :
                 _.isEmpty(subWorkflowId) && [

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -85,7 +85,7 @@ const WorkflowBreadcrumb = ({ workflowPath, loadWorkflow, updateWorkflowPath }) 
       !isLast && span(' > ')
     ])
   })
-  return div({ style: { marginBottom: '10px' } }, [workflowPathRender])
+  return div({ 'data-testid': 'workflow-path', style: { marginBottom: '10px' } }, [workflowPathRender])
 }
 
 ////////CALL TABLE///////////////////////
@@ -94,7 +94,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
   const [statusFilter, setStatusFilter] = useState([])
   const [filteredCallObjects, setFilteredCallObjects] = useState([])
   //NOTE: workflowPath is used to load the workflow in the explorer, implement after the table update is confirmed to be working
-  const [workflowPath, setWorkflowPath] = useState([{id: workflowId, workflowName}])
+  const [workflowPath, setWorkflowPath] = useState([{ id: workflowId, workflowName }])
 
   useEffect(() => {
     if (defaultFailedFilter) {
@@ -126,7 +126,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
 
   const updateWorkflowPath = useCallback((id, workflowName) => {
     const currentIndex = workflowPath.findIndex(workflow => workflow.id === id)
-    if(currentIndex !== -1) {
+    if (currentIndex !== -1) {
       setWorkflowPath(workflowPath.slice(0, currentIndex + 1))
     } else {
       setWorkflowPath([...workflowPath, { id, workflowName }])
@@ -261,11 +261,11 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
                   }
               const linkTemplate = enableExplorer && !_.isEmpty(subWorkflowId) ?
                 [h(Link, {
-                  'data-testid': `view-subworkflow-${subWorkflowId}-link`,
+                  'data-testid': `view-subworkflow-${subWorkflowId}`,
                   onClick: () => {
                     loadWorkflow(subWorkflowId, updateWorkflowPath)
                   }
-                }, ['View subworkflow'])] :
+                }, ['View sub-workflow'])] :
                 _.isEmpty(subWorkflowId) && [
                   h(
                     Link,

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -76,10 +76,12 @@ const SearchBar = ({ filterFn }) => {
 }
 
 ////////CALL TABLE///////////////////////
-const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal }) => {
+const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showTaskDataModal, loadWorkflow, enableExplorer = false, workflowName }) => {
   const [sort, setSort] = useState({ field: 'index', direction: 'asc' })
   const [statusFilter, setStatusFilter] = useState([])
   const [filteredCallObjects, setFilteredCallObjects] = useState([])
+  //NOTE: workflowPath is used to load the workflow in the explorer, implement after the table update is confirmed to be working
+  const [workflowPath, setWorkflowPath] = useState([workflowName])
 
   useEffect(() => {
     if (defaultFailedFilter) {
@@ -111,6 +113,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
 
   return div([
     label({
+      isRendered: !enableExplorer,
       style: {
         fontWeight: 700
       }
@@ -126,7 +129,7 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
           flexGrow: 2
         }
       }, [
-        div({ 'data-testid': 'status-dropdown-filter', style: { flexBasis: 250, marginRight: '20px' } }, [
+        div({ 'data-testid': 'status-dropdown-filter', style: { flexBasis: 250, marginRight: '20px' }, isRendered: !enableExplorer }, [
           h(Select, {
             isClearable: true,
             isMulti: true,
@@ -221,32 +224,62 @@ const CallTable = ({ tableData, defaultFailedFilter = false, showLogModal, showT
             field: 'logs',
             headerRenderer: () => h(HeaderCell, { fontWeight: 500 }, ['Logs']),
             cellRenderer: (({ rowIndex }) => {
-              const { stdout, stderr, inputs, outputs } = filteredCallObjects[rowIndex]
-              return div({
-                style: {
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 1fr',
-                  gridColumnGap: '0.3em',
-                  gridRowGap: '0.3em'
-                }
-              }, [
-                h(Link, {
-                  'data-testid': 'inputs-modal-link',
-                  onClick: () => showTaskDataModal('Inputs', inputs)
-                }, ['Inputs']),
-                h(Link, {
-                  'data-testid': 'outputs-modal-link',
-                  onClick: () => showTaskDataModal('Outputs', outputs)
-                }, ['Outputs']),
-                h(Link, {
-                  'data-testid': 'stdout-modal-link',
-                  onClick: () => showLogModal(stdout, true)
-                }, ['stdout']),
-                h(Link, {
-                  'data-testid': 'stderr-modal-link',
-                  onClick: () => showLogModal(stderr, true)
-                }, 'stderr')
-              ])
+              const { stdout, stderr, inputs, outputs, subWorkflowId } = filteredCallObjects[rowIndex]
+              const style =
+                enableExplorer && !_.isEmpty(subWorkflowId) ?
+                  {
+                    display: 'flex',
+                    justifyContent: 'flex-start'
+                  } :
+                  {
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gridColumnGap: '0.3em',
+                    gridRowGap: '0.3em'
+                  }
+              const linkTemplate = enableExplorer && !_.isEmpty(subWorkflowId) ?
+                [h(Link, {
+                  'data-testid': `view-subworkflow-${subWorkflowId}-link`,
+                  onClick: () => {
+                    //NOTE: defined callback function to execute breadcrumb update here and pass it into loadWorkflow
+                    loadWorkflow(subWorkflowId)
+                  }
+                }, ['View subworkflow'])] :
+                _.isEmpty(subWorkflowId) && [
+                  h(
+                    Link,
+                    {
+                      'data-testid': 'inputs-modal-link',
+                      onClick: () => showTaskDataModal('Inputs', inputs)
+                    },
+                    ['Inputs']
+                  ),
+                  h(
+                    Link,
+                    {
+                      'data-testid': 'outputs-modal-link',
+                      onClick: () => showTaskDataModal('Outputs', outputs)
+                    },
+                    ['Outputs']
+                  ),
+                  h(
+                    Link,
+                    {
+                      'data-testid': 'stdout-modal-link',
+                      onClick: () => showLogModal(stdout, true)
+                    },
+                    ['stdout']
+                  ),
+                  h(
+                    Link,
+                    {
+                      'data-testid': 'stderr-modal-link',
+                      onClick: () => showLogModal(stderr, true)
+                    },
+                    'stderr'
+                  )
+                ]
+              return div({ style }, linkTemplate)
             })
           }
         ]


### PR DESCRIPTION
Addresses [WX-1111](https://broadworkbench.atlassian.net/browse/WX-1111)

PR updates `CallTable.js` to allow for workflow exploration on Successful workflows. Feature will use existing Cromwell metadata API to query sub-workflow data as the user data dives via `View sub-workflow` button. A "breadcrumb" of the current path is rendered above the table and can be used to navigate back to previously traversed segments.

[WX-1111]: https://broadworkbench.atlassian.net/browse/WX-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ