### PR TITLE
[WM-1961] Typecheck WDS Lookups

### DIFF
--- a/src/components/InputsTable.js
+++ b/src/components/InputsTable.js
@@ -9,7 +9,7 @@ import {
   ParameterValueTextInput,
   parseMethodString,
   RecordLookupSelect,
-  StructBuilderLink,
+  StructBuilderLink, typeMatch,
   WithWarnings
 } from 'src/components/submission-common'
 import { FlexTable, HeaderCell, InputsButtonRow, Sortable, TextCell } from 'src/components/table'
@@ -54,6 +54,7 @@ const InputsTable = props => {
   )(inputTableData)
 
   const recordLookup = rowIndex => {
+    const type = _.get(`${inputTableData[rowIndex].configurationIndex}.input_type`, configuredInputDefinition)
     const source = _.get(`${inputTableData[rowIndex].configurationIndex}.source`, configuredInputDefinition)
     const setSource = source => {
       setConfiguredInputDefinition(
@@ -63,7 +64,7 @@ const InputsTable = props => {
     return h(RecordLookupSelect, {
       source,
       setSource,
-      dataTableAttributes
+      dataTableAttributes: _.pickBy(wdsType => typeMatch(type, wdsType.datatype))(dataTableAttributes)
     })
   }
 

--- a/src/components/InputsTable.js
+++ b/src/components/InputsTable.js
@@ -50,7 +50,7 @@ const InputsTable = props => {
   )(configuredInputDefinition)
 
   const inputRowsInDataTable = _.filter(
-    row => _.has(row.variable, dataTableAttributes) && row.source.type === 'none'
+    row => _.has(row.variable, dataTableAttributes) && row.source.type === 'none' && typeMatch(row.input_type, _.get(`${row.variable}.datatype`, dataTableAttributes))
   )(inputTableData)
 
   const recordLookup = rowIndex => {
@@ -92,7 +92,7 @@ const InputsTable = props => {
   const sourceNone = rowIndex => {
     return h(TextCell,
       { style: Utils.inputTypeStyle(inputTableData[rowIndex].input_type) },
-      Utils.cond([_.has(inputTableData[rowIndex].variable, dataTableAttributes), () => ['Autofill ', h(Link, {
+      Utils.cond([_.some(input => input.variable === inputTableData[rowIndex].variable)(inputRowsInDataTable), () => ['Autofill ', h(Link, {
         style: {
           textDecoration: 'underline'
         },

--- a/src/components/InputsTable.js
+++ b/src/components/InputsTable.js
@@ -108,7 +108,7 @@ const InputsTable = props => {
     )
   }
 
-  return h(div, { style: { height: 'calc(100% - 3rem)' } }, [
+  return h(div, { style: { height: '100%' } }, [
     h(InputsButtonRow, {
       optionalButtonProps: {
         includeOptionalInputs, setIncludeOptionalInputs
@@ -120,84 +120,86 @@ const InputsTable = props => {
         searchFilter, setSearchFilter
       }
     }),
-    h(AutoSizer, [({ width, height }) => {
-      return h(div, {}, [
-        structBuilderVisible && h(StructBuilderModal, {
-          structName: _.get('variable', inputTableData[structBuilderRow]),
-          structType: _.get('input_type', inputTableData[structBuilderRow]),
-          structSource: _.get('source', inputTableData[structBuilderRow]),
-          setStructSource: source => setConfiguredInputDefinition(
-            _.set(`${inputTableData[structBuilderRow].configurationIndex}.source`, source, configuredInputDefinition)
-          ),
-          dataTableAttributes,
-          onDismiss: () => {
-            setStructBuilderVisible(false)
-          }
-        }),
-        h(FlexTable, {
-          'aria-label': 'input-table',
-          rowCount: inputTableData.length,
-          sort: inputTableSort,
-          readOnly: false,
-          height: !includeOptionalInputs || _.some(row => row.optional, inputTableData) || inputRowsInDataTable.length > 0 ? 0.92 * height : height,
-          width,
-          columns: [
-            {
-              size: { basis: 250, grow: 0 },
-              field: 'taskName',
-              headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'taskName', onSort: setInputTableSort }, [h(HeaderCell, ['Task name'])]),
-              cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, { style: { fontWeight: 500 } }, [inputTableData[rowIndex].taskName])
-              }
-            },
-            {
-              size: { basis: 360, grow: 0 },
-              field: 'variable',
-              headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'variable', onSort: setInputTableSort }, [h(HeaderCell, ['Variable'])]),
-              cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].variable])
-              }
-            },
-            {
-              size: { basis: 160, grow: 0 },
-              field: 'inputTypeStr',
-              headerRenderer: () => h(HeaderCell, ['Type']),
-              cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].inputTypeStr])
-              }
-            },
-            {
-              size: { basis: 300, grow: 0 },
-              headerRenderer: () => h(HeaderCell, ['Input sources']),
-              cellRenderer: ({ rowIndex }) => {
-                return InputSourceSelect({
-                  source: _.get('source', inputTableData[rowIndex]),
-                  inputType: _.get('input_type', inputTableData[rowIndex]),
-                  setSource: source => setConfiguredInputDefinition(
-                    _.set(`[${inputTableData[rowIndex].configurationIndex}].source`, source, configuredInputDefinition))
-                })
-              }
-            },
-            {
-              headerRenderer: () => h(HeaderCell, ['Attribute']),
-              cellRenderer: ({ rowIndex }) => {
-                const source = _.get(`${rowIndex}.source`, inputTableData)
-                const inputName = _.get(`${rowIndex}.input_name`, inputTableData)
-                return h(WithWarnings, {
-                  baseComponent: Utils.switchCase(source.type || 'none',
-                    ['record_lookup', () => recordLookup(rowIndex)],
-                    ['literal', () => parameterValueSelect(rowIndex)],
-                    ['object_builder', () => structBuilderLink(rowIndex)],
-                    ['none', () => sourceNone(rowIndex)]
-                  ),
-                  message: _.find(message => message.name === inputName)(inputValidations)
-                })
-              }
+    h(div, { style: { height: 'calc(100% - 2.5rem)' } }, [
+      h(AutoSizer, [({ width, height }) => {
+        return h(div, {}, [
+          structBuilderVisible && h(StructBuilderModal, {
+            structName: _.get('variable', inputTableData[structBuilderRow]),
+            structType: _.get('input_type', inputTableData[structBuilderRow]),
+            structSource: _.get('source', inputTableData[structBuilderRow]),
+            setStructSource: source => setConfiguredInputDefinition(
+              _.set(`${inputTableData[structBuilderRow].configurationIndex}.source`, source, configuredInputDefinition)
+            ),
+            dataTableAttributes,
+            onDismiss: () => {
+              setStructBuilderVisible(false)
             }
-          ]
-        })
-      ])
-    }])
+          }),
+          h(FlexTable, {
+            'aria-label': 'input-table',
+            rowCount: inputTableData.length,
+            sort: inputTableSort,
+            readOnly: false,
+            height,
+            width,
+            columns: [
+              {
+                size: { basis: 250, grow: 0 },
+                field: 'taskName',
+                headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'taskName', onSort: setInputTableSort }, [h(HeaderCell, ['Task name'])]),
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, { style: { fontWeight: 500 } }, [inputTableData[rowIndex].taskName])
+                }
+              },
+              {
+                size: { basis: 360, grow: 0 },
+                field: 'variable',
+                headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'variable', onSort: setInputTableSort }, [h(HeaderCell, ['Variable'])]),
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].variable])
+                }
+              },
+              {
+                size: { basis: 160, grow: 0 },
+                field: 'inputTypeStr',
+                headerRenderer: () => h(HeaderCell, ['Type']),
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].inputTypeStr])
+                }
+              },
+              {
+                size: { basis: 300, grow: 0 },
+                headerRenderer: () => h(HeaderCell, ['Input sources']),
+                cellRenderer: ({ rowIndex }) => {
+                  return InputSourceSelect({
+                    source: _.get('source', inputTableData[rowIndex]),
+                    inputType: _.get('input_type', inputTableData[rowIndex]),
+                    setSource: source => setConfiguredInputDefinition(
+                      _.set(`[${inputTableData[rowIndex].configurationIndex}].source`, source, configuredInputDefinition))
+                  })
+                }
+              },
+              {
+                headerRenderer: () => h(HeaderCell, ['Attribute']),
+                cellRenderer: ({ rowIndex }) => {
+                  const source = _.get(`${rowIndex}.source`, inputTableData)
+                  const inputName = _.get(`${rowIndex}.input_name`, inputTableData)
+                  return h(WithWarnings, {
+                    baseComponent: Utils.switchCase(source.type || 'none',
+                      ['record_lookup', () => recordLookup(rowIndex)],
+                      ['literal', () => parameterValueSelect(rowIndex)],
+                      ['object_builder', () => structBuilderLink(rowIndex)],
+                      ['none', () => sourceNone(rowIndex)]
+                    ),
+                    message: _.find(message => message.name === inputName)(inputValidations)
+                  })
+                }
+              }
+            ]
+          })
+        ])
+      }])
+    ])
   ])
 }
 

--- a/src/components/InputsTable.test.js
+++ b/src/components/InputsTable.test.js
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom'
+
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import _ from 'lodash/fp'
+import { h } from 'react-hyperscript-helpers'
+import InputsTable from 'src/components/InputsTable'
+import { runSetInputDef, typesResponse } from 'src/libs/mock-responses'
+
+
+describe('Input table source updates', () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 1000 })
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 800 })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Record lookup only shows attributes with matching type', async () => {
+    const selectedDataTable = typesResponse[0]
+    const configuredInputDefinition = runSetInputDef
+    const setConfiguredInputDefinition = jest.fn()
+    const inputTableSort = { field: '', direction: 'asc' }
+    const setInputTableSort = jest.fn()
+    const inputValidations = _.map(({ input_name: name }) => ({ name, type: 'none' }))(runSetInputDef)
+
+    render(h(InputsTable, {
+      selectedDataTable,
+      configuredInputDefinition, setConfiguredInputDefinition,
+      inputTableSort, setInputTableSort,
+      inputValidations
+    }))
+
+    const table = await screen.findByRole('table')
+    const rows = within(table).queryAllByRole('row')
+    expect(rows.length).toBe(4)
+    const cells1 = within(rows[1]).queryAllByRole('cell')
+    const cells2 = within(rows[2]).queryAllByRole('cell')
+
+    within(cells1[0]).getByText('foo')
+    within(cells1[1]).getByText('foo_rating_workflow_var')
+    within(cells1[2]).getByText('Int')
+    within(cells1[3]).getByText('Fetch from Data Table')
+    const fooRecord = within(cells1[4]).getByText('foo_rating')
+
+    within(cells2[0]).getByText('target_workflow_1')
+    within(cells2[1]).getByText('bar_string_workflow_var')
+    within(cells2[2]).getByText('String')
+    within(cells2[3]).getByText('Fetch from Data Table')
+    const barRecord = within(cells2[4]).getByText('bar_string')
+
+    // see what records are available for Int input (foo)
+    // foo_rating is the only NUMBER attribute
+    await userEvent.click(fooRecord)
+    const fooRecordOptions = within(screen.getByRole('listbox')).getAllByText(/[[a-z]|[A-Z]|[0-9]]+/i)
+    expect(fooRecordOptions).toHaveLength(1)
+
+    // see what records are available for String input (bar)
+    // bar_string and sys_name are STRING attributes, and foo_rating (NUMBER) can be coerced to string
+    await userEvent.click(barRecord)
+    const barRecordOptions = within(screen.getByRole('listbox')).getAllByText(/[[a-z]|[A-Z]|[0-9]]+/i)
+    expect(barRecordOptions).toHaveLength(3)
+  })
+})

--- a/src/components/StructBuilder.js
+++ b/src/components/StructBuilder.js
@@ -8,7 +8,7 @@ import {
   InputSourceSelect,
   ParameterValueTextInput,
   RecordLookupSelect,
-  StructBuilderLink,
+  StructBuilderLink, typeMatch,
   validateInputs,
   WithWarnings
 } from 'src/components/submission-common'
@@ -170,7 +170,7 @@ export const StructBuilder = props => {
                       () => h(RecordLookupSelect, {
                         source: innerStructSource,
                         setSource: setInnerStructSource,
-                        dataTableAttributes
+                        dataTableAttributes: _.pickBy(wdsType => typeMatch(currentStructType.fields[rowIndex].field_type, wdsType.datatype))(dataTableAttributes)
                       })],
                     ['object_builder',
                       () => h(StructBuilderLink, {

--- a/src/components/StructBuilder.js
+++ b/src/components/StructBuilder.js
@@ -106,111 +106,113 @@ export const StructBuilder = props => {
         searchFilter, setSearchFilter
       }
     }),
-    h(AutoSizer, [({ width, height }) => {
-      return h(div, {}, [
-        h(FlexTable, {
-          'aria-label': 'struct-table',
-          rowCount: inputTableData.length,
-          readOnly: false,
-          height: ((!includeOptionalInputs || _.some(row => row.field_type.type === 'optional', currentStructType.fields)) ? height * 0.92 : height) - breadcrumbsHeight,
-          width,
-          columns: [
-            {
-              size: { basis: 250, grow: 0 },
-              field: 'struct',
-              headerRenderer: () => h(HeaderCell, ['Struct']),
-              cellRenderer: () => {
-                return h(TextCell, { style: { fontWeight: 500 } }, [currentStructName])
-              }
-            },
-            {
-              size: { basis: 160, grow: 0 },
-              field: 'field',
-              headerRenderer: () => h(HeaderCell, ['Variable']),
-              cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) }, [inputTableData[rowIndex].field_name])
-              }
-            },
-            {
-              size: { basis: 160, grow: 0 },
-              field: 'type',
-              headerRenderer: () => h(HeaderCell, ['Type']),
-              cellRenderer: ({ rowIndex }) => {
-                return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) }, [inputTableData[rowIndex].inputTypeStr])
-              }
-            },
-            {
-              size: { basis: 350, grow: 0 },
-              headerRenderer: () => h(HeaderCell, ['Input sources']),
-              cellRenderer: ({ rowIndex }) => {
-                const configurationIndex = inputTableData[rowIndex].configurationIndex
-                const typePath = buildStructTypePath([configurationIndex])
-                const typeNamePath = buildStructTypeNamePath([configurationIndex])
-                const sourcePath = buildStructSourcePath([configurationIndex])
-                const sourceNamePath = buildStructSourceNamePath([configurationIndex])
-                return InputSourceSelect({
-                  source: _.get(sourcePath, currentStructSource),
-                  setSource: source => {
+    h(div, { style: { height: `calc(500px - ${breadcrumbsHeight}px - 2.5rem)` } }, [
+      h(AutoSizer, [({ width, height }) => {
+        return h(div, {}, [
+          h(FlexTable, {
+            'aria-label': 'struct-table',
+            rowCount: inputTableData.length,
+            readOnly: false,
+            height,
+            width,
+            columns: [
+              {
+                size: { basis: 250, grow: 0 },
+                field: 'struct',
+                headerRenderer: () => h(HeaderCell, ['Struct']),
+                cellRenderer: () => {
+                  return h(TextCell, { style: { fontWeight: 500 } }, [currentStructName])
+                }
+              },
+              {
+                size: { basis: 160, grow: 0 },
+                field: 'field',
+                headerRenderer: () => h(HeaderCell, ['Variable']),
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) }, [inputTableData[rowIndex].field_name])
+                }
+              },
+              {
+                size: { basis: 160, grow: 0 },
+                field: 'type',
+                headerRenderer: () => h(HeaderCell, ['Type']),
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) }, [inputTableData[rowIndex].inputTypeStr])
+                }
+              },
+              {
+                size: { basis: 350, grow: 0 },
+                headerRenderer: () => h(HeaderCell, ['Input sources']),
+                cellRenderer: ({ rowIndex }) => {
+                  const configurationIndex = inputTableData[rowIndex].configurationIndex
+                  const typePath = buildStructTypePath([configurationIndex])
+                  const typeNamePath = buildStructTypeNamePath([configurationIndex])
+                  const sourcePath = buildStructSourcePath([configurationIndex])
+                  const sourceNamePath = buildStructSourceNamePath([configurationIndex])
+                  return InputSourceSelect({
+                    source: _.get(sourcePath, currentStructSource),
+                    setSource: source => {
+                      const newSource = _.flow([
+                        _.set(sourceNamePath, _.get(sourceNamePath, currentStructSource) || _.get(typeNamePath, currentStructType)),
+                        _.set(sourcePath, source)
+                      ])(currentStructSource)
+                      setCurrentStructSource(newSource)
+                    },
+                    inputType: _.get(typePath, currentStructType)
+                  })
+                }
+              },
+              {
+                headerRenderer: () => h(HeaderCell, ['Attribute']),
+                cellRenderer: ({ rowIndex }) => {
+                // rowIndex is the index of this input in the currently displayed table
+                // configurationIndex is the index of this input the struct input definition
+                  const configurationIndex = inputTableData[rowIndex].configurationIndex
+                  const typeNamePath = buildStructTypeNamePath([configurationIndex])
+                  const sourcePath = buildStructSourcePath([configurationIndex])
+                  const sourceNamePath = buildStructSourceNamePath([configurationIndex])
+                  const innerStructSource = _.get(sourcePath, currentStructSource)
+                  const inputName = inputTableData[rowIndex].field_name
+                  const setInnerStructSource = source => {
                     const newSource = _.flow([
                       _.set(sourceNamePath, _.get(sourceNamePath, currentStructSource) || _.get(typeNamePath, currentStructType)),
                       _.set(sourcePath, source)
                     ])(currentStructSource)
                     setCurrentStructSource(newSource)
-                  },
-                  inputType: _.get(typePath, currentStructType)
-                })
-              }
-            },
-            {
-              headerRenderer: () => h(HeaderCell, ['Attribute']),
-              cellRenderer: ({ rowIndex }) => {
-                // rowIndex is the index of this input in the currently displayed table
-                // configurationIndex is the index of this input the struct input definition
-                const configurationIndex = inputTableData[rowIndex].configurationIndex
-                const typeNamePath = buildStructTypeNamePath([configurationIndex])
-                const sourcePath = buildStructSourcePath([configurationIndex])
-                const sourceNamePath = buildStructSourceNamePath([configurationIndex])
-                const innerStructSource = _.get(sourcePath, currentStructSource)
-                const inputName = inputTableData[rowIndex].field_name
-                const setInnerStructSource = source => {
-                  const newSource = _.flow([
-                    _.set(sourceNamePath, _.get(sourceNamePath, currentStructSource) || _.get(typeNamePath, currentStructType)),
-                    _.set(sourcePath, source)
-                  ])(currentStructSource)
-                  setCurrentStructSource(newSource)
+                  }
+                  return h(WithWarnings, {
+                    baseComponent: Utils.switchCase(innerStructSource ? innerStructSource.type : 'none',
+                      ['literal',
+                        () => h(ParameterValueTextInput, {
+                          id: `structbuilder-table-attribute-select-${rowIndex}`,
+                          inputType: inputTableData[rowIndex].field_type,
+                          source: innerStructSource,
+                          setSource: setInnerStructSource
+                        })],
+                      ['record_lookup',
+                        () => h(RecordLookupSelect, {
+                          source: innerStructSource,
+                          setSource: setInnerStructSource,
+                          dataTableAttributes: _.pickBy(wdsType => typeMatch(currentStructType.fields[rowIndex].field_type, wdsType.datatype))(dataTableAttributes)
+                        })],
+                      ['object_builder',
+                        () => h(StructBuilderLink, {
+                          onClick: () => setStructIndexPath([...structIndexPath, configurationIndex])
+                        })],
+                      ['none', () => h(TextCell,
+                        { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) },
+                        [inputTableData[rowIndex].optional ? 'Optional' : 'This input is required']
+                      )]
+                    ),
+                    message: _.find(validation => validation.name === inputName)(inputValidations)
+                  })
                 }
-                return h(WithWarnings, {
-                  baseComponent: Utils.switchCase(innerStructSource ? innerStructSource.type : 'none',
-                    ['literal',
-                      () => h(ParameterValueTextInput, {
-                        id: `structbuilder-table-attribute-select-${rowIndex}`,
-                        inputType: inputTableData[rowIndex].field_type,
-                        source: innerStructSource,
-                        setSource: setInnerStructSource
-                      })],
-                    ['record_lookup',
-                      () => h(RecordLookupSelect, {
-                        source: innerStructSource,
-                        setSource: setInnerStructSource,
-                        dataTableAttributes: _.pickBy(wdsType => typeMatch(currentStructType.fields[rowIndex].field_type, wdsType.datatype))(dataTableAttributes)
-                      })],
-                    ['object_builder',
-                      () => h(StructBuilderLink, {
-                        onClick: () => setStructIndexPath([...structIndexPath, configurationIndex])
-                      })],
-                    ['none', () => h(TextCell,
-                      { style: Utils.inputTypeStyle(inputTableData[rowIndex].field_type) },
-                      [inputTableData[rowIndex].optional ? 'Optional' : 'This input is required']
-                    )]
-                  ),
-                  message: _.find(validation => validation.name === inputName)(inputValidations)
-                })
               }
-            }
-          ]
-        })
-      ])
-    }])
+            ]
+          })
+        ])
+      }])
+    ])
   ])
 }
 

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -380,6 +380,7 @@ export const typeMatch = (cbasType, wdsType) => {
       ['Int', () => wdsType === 'NUMBER'],
       ['Float', () => wdsType === 'NUMBER'],
       ['Boolean', () => wdsType === 'BOOLEAN'],
+      ['File', () => wdsType === 'FILE' || wdsType === 'STRING'],
       [Utils.DEFAULT, () => true]
     )
   } else if (unwrappedCbasType.type === 'array') {

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -373,18 +373,29 @@ const validateRequiredHasSource = (inputSource, inputType) => {
   } else return { type: 'error', message: 'This attribute is required' }
 }
 
-const validateRecordLookup = (source, recordAttributes) => {
-  if (source) {
-    if (source.type === 'record_lookup' && !recordAttributes.includes(source.record_attribute)) {
-      return { type: 'error', message: 'This attribute doesn\'t exist in the data table' }
-    }
-    if (source.type === 'object_builder') {
-      if (source.fields) {
-        const fieldsValidated = _.map(field => field && validateRecordLookup(field.source, recordAttributes) === true, source.fields)
+export const typeMatch = (cbasType, wdsType) => {
+  return Utils.switchCase(unwrapOptional(cbasType).primitive_type,
+    ['Int', () => wdsType === 'NUMBER'],
+    ['Float', () => wdsType === 'NUMBER'],
+    ['Boolean', () => wdsType === 'BOOLEAN'],
+    [Utils.DEFAULT, () => true]
+  )
+}
+
+const validateRecordLookup = (inputSource, inputType, recordAttributes) => {
+  if (inputSource) {
+    if (inputSource.type === 'record_lookup') {
+      if (!_.has(inputSource.record_attribute)(recordAttributes)) {
+        return { type: 'error', message: 'This attribute doesn\'t exist in the data table' }
+      } else if (!typeMatch(inputType, _.get(`${inputSource.record_attribute}.datatype`)(recordAttributes))) {
+        return { type: 'error', message: 'Provided type does not match expected type' }
+      } else return true
+    } else if (inputSource.type === 'object_builder') {
+      if (inputSource.fields) {
+        const fieldsValidated = _.map(field => field && validateRecordLookup(field.source, field.field_type, recordAttributes) === true, _.merge(inputType.fields, inputSource.fields))
         return _.every(Boolean, fieldsValidated) || { type: 'error', message: 'One of this struct\'s inputs has an invalid configuration' }
       } else return { type: 'error', message: 'One of this struct\'s inputs has an invalid configuration' }
-    }
-    return true
+    } else return true
   } else return true
 }
 
@@ -493,7 +504,7 @@ const validateInput = (input, dataTableAttributes) => {
     return requiredHasSource
   }
   // then validate that record lookups are good (exist in table)
-  const validRecordLookup = validateRecordLookup(input.source, _.keys(dataTableAttributes))
+  const validRecordLookup = validateRecordLookup(input.source, inputType, dataTableAttributes)
   if (validRecordLookup !== true) {
     return validRecordLookup
   }

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -385,6 +385,8 @@ export const typeMatch = (cbasType, wdsType) => {
     )
   } else if (unwrappedCbasType.type === 'array') {
     return _.startsWith('ARRAY_OF_')(wdsType) && typeMatch(unwrappedCbasType.array_type, _.replace('ARRAY_OF_', '')(wdsType))
+  } else if (unwrappedCbasType.type === 'struct') {
+    return wdsType === 'JSON'
   } else return true
 }
 

--- a/src/components/submission-common.js
+++ b/src/components/submission-common.js
@@ -374,12 +374,17 @@ const validateRequiredHasSource = (inputSource, inputType) => {
 }
 
 export const typeMatch = (cbasType, wdsType) => {
-  return Utils.switchCase(unwrapOptional(cbasType).primitive_type,
-    ['Int', () => wdsType === 'NUMBER'],
-    ['Float', () => wdsType === 'NUMBER'],
-    ['Boolean', () => wdsType === 'BOOLEAN'],
-    [Utils.DEFAULT, () => true]
-  )
+  const unwrappedCbasType = unwrapOptional(cbasType)
+  if (unwrappedCbasType.type === 'primitive') {
+    return Utils.switchCase(unwrappedCbasType.primitive_type,
+      ['Int', () => wdsType === 'NUMBER'],
+      ['Float', () => wdsType === 'NUMBER'],
+      ['Boolean', () => wdsType === 'BOOLEAN'],
+      [Utils.DEFAULT, () => true]
+    )
+  } else if (unwrappedCbasType.type === 'array') {
+    return _.startsWith('ARRAY_OF_')(wdsType) && typeMatch(unwrappedCbasType.array_type, _.replace('ARRAY_OF_', '')(wdsType))
+  } else return true
 }
 
 const validateRecordLookup = (inputSource, inputType, recordAttributes) => {

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -387,7 +387,7 @@ describe('typeMatch', () => {
     ['File', 'NUMBER', false],
     ['File', 'BOOLEAN', false],
     ['File', 'STRING', true],
-    ['File', 'FILE', true],
+    ['File', 'FILE', true]
   ]
 
   test.each(testCases)('(CBAS) %s does or does not match (WDS) %s regardless of optional', (cbas, wds, _shouldMatch) => {

--- a/src/components/submission-common.test.js
+++ b/src/components/submission-common.test.js
@@ -371,18 +371,23 @@ describe('typeMatch', () => {
     ['Int', 'NUMBER', true],
     ['Int', 'BOOLEAN', false],
     ['Int', 'STRING', false],
+    ['Int', 'FILE', false],
     ['Float', 'NUMBER', true],
     ['Float', 'BOOLEAN', false],
     ['Float', 'STRING', false],
+    ['Float', 'FILE', false],
     ['Boolean', 'NUMBER', false],
     ['Boolean', 'BOOLEAN', true],
     ['Boolean', 'STRING', false],
+    ['Boolean', 'FILE', false],
     ['String', 'NUMBER', true],
     ['String', 'BOOLEAN', true],
     ['String', 'STRING', true],
-    ['File', 'NUMBER', true],
-    ['File', 'BOOLEAN', true],
-    ['File', 'STRING', true]
+    ['String', 'FILE', true],
+    ['File', 'NUMBER', false],
+    ['File', 'BOOLEAN', false],
+    ['File', 'STRING', true],
+    ['File', 'FILE', true],
   ]
 
   test.each(testCases)('(CBAS) %s does or does not match (WDS) %s regardless of optional', (cbas, wds, _shouldMatch) => {
@@ -397,7 +402,7 @@ describe('typeMatch', () => {
     // if CBAS expects array but WDS does not provide, it's no good
     expect(typeMatch(array(primitive(cbas)), wds)).toBe(false)
     // if CBAS expects a string but WDS provides arrays... we can convert that to a string
-    expect(typeMatch(primitive(cbas), arrayWDS(wds))).toBe(cbas === 'String' || cbas === 'File')
+    expect(typeMatch(primitive(cbas), arrayWDS(wds))).toBe(cbas === 'String')
     // Otherwise arrays should typematch the same as if comparing their children
     expect(typeMatch(array(primitive(cbas)), arrayWDS(wds))).toBe(shouldMatch)
   })


### PR DESCRIPTION

https://github.com/DataBiosphere/cbas-ui/assets/67511512/944b4f5e-d293-419e-90ed-e00e6c8a0447

Record lookups are only allowed to be selected from WDS attributes that match expected input types (or attributes that we can coerce, e.g. Int column provided to String input). Record lookups are also validated by this type matching, in case the user switches tables and now has records selected that exist in the new table but have a different type.