### PR TITLE
[WX-1110] Fetch and show failed tasks for Failed Workflows on RunDetails.js

### DIFF
--- a/src/components/TroubleshootingBox.js
+++ b/src/components/TroubleshootingBox.js
@@ -22,11 +22,11 @@ export const TroubleshootingBox = ({ logUri, submissionId, workflowId, showLogMo
     div({}, [span({ style: { fontSize: 16, fontWeight: 'bold' } }, ['Troubleshooting?'])]),
     div({ 'data-testid': 'workflow-id-container', style: { display: 'flex', justifyContent: 'space-between' } }, [
       span({}, [span({ style: { marginRight: '0.5rem', fontWeight: 'bold' } }, ['Workflow ID: ']), span({}, [workflowId])]),
-      span({ 'data-testid': 'workflow-clipboard-button' }, [h(ClipboardButton, { text: workflowId })])
+      span({ 'data-testid': 'workflow-clipboard-button' }, [h(ClipboardButton, { text: workflowId, 'aria-label': 'Copy workflow id' })])
     ]),
     div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
       span({}, [span({ style: { marginRight: '0.5rem', fontWeight: 'bold' } }, ['Submission ID: ']), span({}, [submissionId])]),
-      span({ 'data-testid': 'submission-clipboard-button' }, [h(ClipboardButton, { text: submissionId })])
+      span({ 'data-testid': 'submission-clipboard-button' }, [h(ClipboardButton, { text: submissionId, 'aria-label': 'Copy submission id' })])
     ]),
     div({ 'data-testid': 'log-link-container', style: { display: 'flex', justifyContent: 'left', paddingTop: '3px' } }, [
       h(Link, { onClick: () => { showLogModal(logUri) } }, [

--- a/src/fixtures/failed-tasks.js
+++ b/src/fixtures/failed-tasks.js
@@ -1,0 +1,496 @@
+export const failedTasks = {
+  'a7087cc0-961e-41f9-98c9-93f980fe73a2': {
+    calls: {
+      'sub_wf_scattering.subSubworkflowHello': [
+        {
+          stdout: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowHello/execution/stdout',
+          shardIndex: -1,
+          runtimeAttributes: {
+            failOnStderr: 'false',
+            continueOnReturnCode: '0',
+            maxRetries: '0'
+          },
+          callCaching: {
+            allowResultReuse: true,
+            hashes: {
+              'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+              'runtime attribute': {
+                docker: 'N/A',
+                continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+                failOnStderr: '68934A3E9455FA72420237EB05902327'
+              },
+              'output expression': {
+                'String out': '0183144CF6617D5341681C6B2F756046'
+              },
+              'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+              'backend name': '509820290D57F333403F490DDE7316F4',
+              'command template': 'E80AE16736B864DC65CEA153382F11F7'
+            },
+            effectiveCallCachingMode: 'ReadAndWriteCache',
+            hit: false,
+            result: 'Cache Miss'
+          },
+          inputs: {},
+          failures: [
+            {
+              message: 'java.lang.Exception: Failed command instantiation',
+              causedBy: [
+                {
+                  message: 'Failed command instantiation',
+                  causedBy: [
+                    {
+                      message: 'Error(s)',
+                      causedBy: [
+                        {
+                          message: 'Divide by zero error: 2 / WomInteger(0)',
+                          causedBy: []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          backend: 'Local',
+          end: '2023-07-11T11:33:09.185Z',
+          start: '2023-07-11T11:32:22.645Z',
+          retryableFailure: false,
+          executionStatus: 'Failed',
+          stderr: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowHello/execution/stderr',
+          callRoot: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowHello',
+          attempt: 1,
+          executionEvents: [
+            {
+              endTime: '2023-07-11T11:32:28.405Z',
+              description: 'WaitingForValueStore',
+              startTime: '2023-07-11T11:32:28.395Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.745Z',
+              description: 'CallCacheReading',
+              startTime: '2023-07-11T11:32:28.593Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.395Z',
+              description: 'RequestingExecutionToken',
+              startTime: '2023-07-11T11:32:22.646Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.593Z',
+              description: 'PreparingJob',
+              startTime: '2023-07-11T11:32:28.405Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:22.646Z',
+              description: 'Pending',
+              startTime: '2023-07-11T11:32:22.645Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:09.132Z',
+              description: 'RunningJob',
+              startTime: '2023-07-11T11:32:28.745Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:09.186Z',
+              description: 'UpdatingJobStore',
+              startTime: '2023-07-11T11:33:09.132Z'
+            }
+          ]
+        }
+      ],
+      'wf_scattering.scatteringGoodbye': [
+        {
+          stdout: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringGoodbye/shard-1/execution/stdout',
+          shardIndex: 1,
+          runtimeAttributes: {
+            failOnStderr: 'false',
+            continueOnReturnCode: '0',
+            maxRetries: '0'
+          },
+          callCaching: {
+            allowResultReuse: true,
+            hashes: {
+              'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+              'runtime attribute': {
+                docker: 'N/A',
+                continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+                failOnStderr: '68934A3E9455FA72420237EB05902327'
+              },
+              'output expression': {
+                'String out': '0183144CF6617D5341681C6B2F756046'
+              },
+              'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+              'backend name': '509820290D57F333403F490DDE7316F4',
+              'command template': 'E80AE16736B864DC65CEA153382F11F7'
+            },
+            effectiveCallCachingMode: 'ReadAndWriteCache',
+            hit: false,
+            result: 'Cache Miss'
+          },
+          inputs: {},
+          failures: [
+            {
+              message: 'java.lang.Exception: Failed command instantiation',
+              causedBy: [
+                {
+                  message: 'Failed command instantiation',
+                  causedBy: [
+                    {
+                      message: 'Error(s)',
+                      causedBy: [
+                        {
+                          message: 'Divide by zero error: 2 / WomInteger(0)',
+                          causedBy: []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          backend: 'Local',
+          end: '2023-07-11T11:33:13.183Z',
+          start: '2023-07-11T11:32:24.706Z',
+          retryableFailure: false,
+          executionStatus: 'Failed',
+          stderr: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringGoodbye/shard-1/execution/stderr',
+          callRoot: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringGoodbye/shard-1',
+          attempt: 1,
+          executionEvents: [
+            {
+              endTime: '2023-07-11T11:33:13.183Z',
+              description: 'UpdatingJobStore',
+              startTime: '2023-07-11T11:33:12.403Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.405Z',
+              description: 'WaitingForValueStore',
+              startTime: '2023-07-11T11:32:28.395Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.395Z',
+              description: 'RequestingExecutionToken',
+              startTime: '2023-07-11T11:32:24.706Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.745Z',
+              description: 'CallCacheReading',
+              startTime: '2023-07-11T11:32:28.693Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:12.403Z',
+              description: 'RunningJob',
+              startTime: '2023-07-11T11:32:28.745Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:24.706Z',
+              description: 'Pending',
+              startTime: '2023-07-11T11:32:24.706Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.693Z',
+              description: 'PreparingJob',
+              startTime: '2023-07-11T11:32:28.405Z'
+            }
+          ]
+        }
+      ],
+      'sub_wf_scattering.subSubworkflowGoodbye': [
+        {
+          stdout: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowGoodbye/shard-2/execution/stdout',
+          shardIndex: 2,
+          runtimeAttributes: {
+            failOnStderr: 'false',
+            continueOnReturnCode: '0',
+            maxRetries: '0'
+          },
+          callCaching: {
+            allowResultReuse: true,
+            hashes: {
+              'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+              'runtime attribute': {
+                docker: 'N/A',
+                continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+                failOnStderr: '68934A3E9455FA72420237EB05902327'
+              },
+              'output expression': {
+                'String out': '0183144CF6617D5341681C6B2F756046'
+              },
+              'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+              'backend name': '509820290D57F333403F490DDE7316F4',
+              'command template': 'E80AE16736B864DC65CEA153382F11F7'
+            },
+            effectiveCallCachingMode: 'ReadAndWriteCache',
+            hit: false,
+            result: 'Cache Miss'
+          },
+          inputs: {},
+          failures: [
+            {
+              message: 'java.lang.Exception: Failed command instantiation',
+              causedBy: [
+                {
+                  message: 'Failed command instantiation',
+                  causedBy: [
+                    {
+                      message: 'Error(s)',
+                      causedBy: [
+                        {
+                          message: 'Divide by zero error: 2 / WomInteger(0)',
+                          causedBy: []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          backend: 'Local',
+          end: '2023-07-11T11:33:14.187Z',
+          start: '2023-07-11T11:32:25.706Z',
+          retryableFailure: false,
+          executionStatus: 'Failed',
+          stderr: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowGoodbye/shard-2/execution/stderr',
+          callRoot: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-sub_wf_scattering/sub_wf_scattering/e4fbfe56-8beb-41e0-9202-03f947b93fac/call-subSubworkflowGoodbye/shard-2',
+          attempt: 1,
+          executionEvents: [
+            {
+              endTime: '2023-07-11T11:32:28.629Z',
+              description: 'PreparingJob',
+              startTime: '2023-07-11T11:32:28.405Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.405Z',
+              description: 'WaitingForValueStore',
+              startTime: '2023-07-11T11:32:28.395Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.395Z',
+              description: 'RequestingExecutionToken',
+              startTime: '2023-07-11T11:32:25.707Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.745Z',
+              description: 'CallCacheReading',
+              startTime: '2023-07-11T11:32:28.629Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:14.187Z',
+              description: 'UpdatingJobStore',
+              startTime: '2023-07-11T11:33:13.883Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:13.883Z',
+              description: 'RunningJob',
+              startTime: '2023-07-11T11:32:28.745Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:25.707Z',
+              description: 'Pending',
+              startTime: '2023-07-11T11:32:25.706Z'
+            }
+          ]
+        }
+      ],
+      'wf_scattering.scatteringHello': [
+        {
+          stdout: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringHello/shard-2/execution/stdout',
+          shardIndex: 2,
+          runtimeAttributes: {
+            failOnStderr: 'false',
+            continueOnReturnCode: '0',
+            maxRetries: '0'
+          },
+          callCaching: {
+            allowResultReuse: true,
+            hashes: {
+              'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+              'runtime attribute': {
+                docker: 'N/A',
+                continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+                failOnStderr: '68934A3E9455FA72420237EB05902327'
+              },
+              'output expression': {
+                'String out': '0183144CF6617D5341681C6B2F756046'
+              },
+              'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+              'backend name': '509820290D57F333403F490DDE7316F4',
+              'command template': 'E80AE16736B864DC65CEA153382F11F7'
+            },
+            effectiveCallCachingMode: 'ReadAndWriteCache',
+            hit: false,
+            result: 'Cache Miss'
+          },
+          inputs: {},
+          failures: [
+            {
+              message: 'java.lang.Exception: Failed command instantiation',
+              causedBy: [
+                {
+                  message: 'Failed command instantiation',
+                  causedBy: [
+                    {
+                      message: 'Error(s)',
+                      causedBy: [
+                        {
+                          message: 'Divide by zero error: 2 / WomInteger(0)',
+                          causedBy: []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          backend: 'Local',
+          end: '2023-07-11T11:33:15.187Z',
+          start: '2023-07-11T11:32:24.705Z',
+          retryableFailure: false,
+          executionStatus: 'Failed',
+          stderr: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringHello/shard-2/execution/stderr',
+          callRoot: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-wf_scattering/wf_scattering/d9bd552f-5887-43b3-903c-099327d30229/call-scatteringHello/shard-2',
+          attempt: 1,
+          executionEvents: [
+            {
+              endTime: '2023-07-11T11:32:28.395Z',
+              description: 'RequestingExecutionToken',
+              startTime: '2023-07-11T11:32:24.706Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:24.706Z',
+              description: 'Pending',
+              startTime: '2023-07-11T11:32:24.706Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:14.823Z',
+              description: 'RunningJob',
+              startTime: '2023-07-11T11:32:28.746Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.405Z',
+              description: 'WaitingForValueStore',
+              startTime: '2023-07-11T11:32:28.395Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.746Z',
+              description: 'CallCacheReading',
+              startTime: '2023-07-11T11:32:28.593Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:15.187Z',
+              description: 'UpdatingJobStore',
+              startTime: '2023-07-11T11:33:14.823Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.593Z',
+              description: 'PreparingJob',
+              startTime: '2023-07-11T11:32:28.405Z'
+            }
+          ]
+        }
+      ],
+      'main_workflow.done': [
+        {
+          stdout: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-done/execution/stdout',
+          shardIndex: -1,
+          runtimeAttributes: {
+            failOnStderr: 'false',
+            continueOnReturnCode: '0',
+            maxRetries: '0'
+          },
+          callCaching: {
+            allowResultReuse: true,
+            hashes: {
+              'output count': 'C4CA4238A0B923820DCC509A6F75849B',
+              'runtime attribute': {
+                docker: 'N/A',
+                continueOnReturnCode: 'CFCD208495D565EF66E7DFF9F98764DA',
+                failOnStderr: '68934A3E9455FA72420237EB05902327'
+              },
+              'output expression': {
+                'String out': '0183144CF6617D5341681C6B2F756046'
+              },
+              'input count': 'CFCD208495D565EF66E7DFF9F98764DA',
+              'backend name': '509820290D57F333403F490DDE7316F4',
+              'command template': 'E80AE16736B864DC65CEA153382F11F7'
+            },
+            effectiveCallCachingMode: 'ReadAndWriteCache',
+            hit: false,
+            result: 'Cache Miss'
+          },
+          inputs: {},
+          failures: [
+            {
+              message: 'java.lang.Exception: Failed command instantiation',
+              causedBy: [
+                {
+                  message: 'Failed command instantiation',
+                  causedBy: [
+                    {
+                      message: 'Error(s)',
+                      causedBy: [
+                        {
+                          message: 'Divide by zero error: 2 / WomInteger(0)',
+                          causedBy: []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          backend: 'Local',
+          end: '2023-07-11T11:33:09.185Z',
+          start: '2023-07-11T11:32:20.512Z',
+          retryableFailure: false,
+          executionStatus: 'Failed',
+          stderr: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-done/execution/stderr',
+          callRoot: '/folderName/cromwell/cromwell-executions/main_workflow/a7087cc0-961e-41f9-98c9-93f980fe73a2/call-done',
+          attempt: 1,
+          executionEvents: [
+            {
+              endTime: '2023-07-11T11:33:08.763Z',
+              description: 'RunningJob',
+              startTime: '2023-07-11T11:32:28.745Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.745Z',
+              description: 'CallCacheReading',
+              startTime: '2023-07-11T11:32:28.672Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.405Z',
+              description: 'WaitingForValueStore',
+              startTime: '2023-07-11T11:32:28.395Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.672Z',
+              description: 'PreparingJob',
+              startTime: '2023-07-11T11:32:28.405Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:20.579Z',
+              description: 'Pending',
+              startTime: '2023-07-11T11:32:20.539Z'
+            },
+            {
+              endTime: '2023-07-11T11:32:28.395Z',
+              description: 'RequestingExecutionToken',
+              startTime: '2023-07-11T11:32:20.579Z'
+            },
+            {
+              endTime: '2023-07-11T11:33:09.186Z',
+              description: 'UpdatingJobStore',
+              startTime: '2023-07-11T11:33:08.763Z'
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/fixtures/test-child-workflow.js
+++ b/src/fixtures/test-child-workflow.js
@@ -5,7 +5,7 @@ export const metadata = {
     'wf_scattering.scatteringHello': [
       {
         stdout:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stdout',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stdout',
         shardIndex: 0,
         runtimeAttributes: {
           maxRetries: '0',
@@ -60,9 +60,9 @@ export const metadata = {
         retryableFailure: false,
         executionStatus: 'Failed',
         stderr:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stderr',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0/execution/stderr',
         callRoot:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-0',
         attempt: 1,
         executionEvents: [
           {
@@ -104,7 +104,7 @@ export const metadata = {
       },
       {
         stdout:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stdout',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stdout',
         shardIndex: 1,
         runtimeAttributes: {
           maxRetries: '0',
@@ -159,9 +159,9 @@ export const metadata = {
         retryableFailure: false,
         executionStatus: 'Failed',
         stderr:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stderr',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1/execution/stderr',
         callRoot:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-1',
         attempt: 1,
         executionEvents: [
           {
@@ -203,7 +203,7 @@ export const metadata = {
       },
       {
         stdout:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stdout',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stdout',
         shardIndex: 2,
         runtimeAttributes: {
           maxRetries: '0',
@@ -258,9 +258,9 @@ export const metadata = {
         retryableFailure: false,
         executionStatus: 'Failed',
         stderr:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stderr',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2/execution/stderr',
         callRoot:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringHello/shard-2',
         attempt: 1,
         executionEvents: [
           {
@@ -304,7 +304,7 @@ export const metadata = {
     'wf_scattering.scatteringGoodbye': [
       {
         stdout:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stdout',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stdout',
         shardIndex: 0,
         runtimeAttributes: {
           maxRetries: '0',
@@ -359,9 +359,9 @@ export const metadata = {
         retryableFailure: false,
         executionStatus: 'Failed',
         stderr:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stderr',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0/execution/stderr',
         callRoot:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-0',
         attempt: 1,
         executionEvents: [
           {
@@ -403,7 +403,7 @@ export const metadata = {
       },
       {
         stdout:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stdout',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stdout',
         shardIndex: 1,
         runtimeAttributes: {
           maxRetries: '0',
@@ -458,9 +458,9 @@ export const metadata = {
         retryableFailure: false,
         executionStatus: 'Failed',
         stderr:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stderr',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1/execution/stderr',
         callRoot:
-          '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1',
+          '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305/call-wf_scattering/wf_scattering/97967c22-bcc1-4946-b9c7-d4375f8b3070/call-scatteringGoodbye/shard-1',
         attempt: 1,
         executionEvents: [
           {
@@ -502,7 +502,7 @@ export const metadata = {
       }
     ]
   },
-  workflowRoot: '/Users/jthomas/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305',
+  workflowRoot: '/Users/username/cromwell/cromwell-executions/main_workflow/be48c79d-f8e8-4a0a-bed4-787a30a60305',
   status: 'Failed',
   parentWorkflowId: 'be48c79d-f8e8-4a0a-bed4-787a30a60305',
   end: '2023-06-18T15:50:28.385Z',

--- a/src/fixtures/test-workflow.js
+++ b/src/fixtures/test-workflow.js
@@ -35,23 +35,23 @@ export const metadata = {
           "set -e\n# fetch SRA metadata on this record\nesearch -db sra -q \"SRR13379731\" | efetch -mode json -json > SRA.json\ncp SRA.json \"SRR13379731.json\"\n\n# pull reads from SRA and make a fully annotated BAM -- must succeed\nCENTER=$(jq -r .EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SUBMISSION.center_name SRA.json)\nPLATFORM=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.PLATFORM | keys[] as $k | \"\\($k)\"' SRA.json)\nMODEL=$(jq -r \".EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.PLATFORM.$PLATFORM.INSTRUMENT_MODEL\" SRA.json)\nSAMPLE=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.IDENTIFIERS.EXTERNAL_ID|select(.namespace == \"BioSample\")|.content' SRA.json)\nLIBRARY=$(jq -r .EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.alias SRA.json)\nRUNDATE=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == \"object\" then .SRAFile.date else [.SRAFile[]|select(.supertype == \"Original\")][0].date end' SRA.json | cut -f 1 -d ' ')\n\nif [ \"$PLATFORM\" = \"OXFORD_NANOPORE\" ]; then\n    # per the SAM/BAM specification\n    SAM_PLATFORM=\"ONT\"\nelse\n    SAM_PLATFORM=\"$PLATFORM\"\nfi\n\nsam-dump --unaligned --header \"SRR13379731\" \\\n    | samtools view -bhS - \\\n    > temp.bam\npicard AddOrReplaceReadGroups \\\n    I=temp.bam \\\n    O=\"SRR13379731.bam\" \\\n    RGID=1 \\\n    RGLB=\"$LIBRARY\" \\\n    RGSM=\"$SAMPLE\" \\\n    RGPL=\"$SAM_PLATFORM\" \\\n    RGPU=\"$LIBRARY\" \\\n    RGPM=\"$MODEL\" \\\n    RGDT=\"$RUNDATE\" \\\n    RGCN=\"$CENTER\" \\\n    VALIDATION_STRINGENCY=SILENT\nrm temp.bam\nsamtools view -H \"SRR13379731.bam\"\n\n# emit numeric WDL outputs\necho $CENTER > OUT_CENTER\necho $PLATFORM > OUT_PLATFORM\necho $SAMPLE > OUT_BIOSAMPLE\necho $LIBRARY > OUT_LIBRARY\necho $RUNDATE > OUT_RUNDATE\nsamtools view -c \"SRR13379731.bam\" | tee OUT_NUM_READS\n\n# pull other metadata from SRA -- allow for silent failures here!\ntouch OUT_MODEL OUT_COLLECTION_DATE OUT_STRAIN OUT_COLLECTED_BY OUT_GEO_LOC\nset +e\njq -r \\\n    .EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.PLATFORM.\"$PLATFORM\".INSTRUMENT_MODEL \\\n    SRA.json | tee OUT_MODEL\njq -r \\\n    '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.SAMPLE_ATTRIBUTES.SAMPLE_ATTRIBUTE[]|select(.TAG == \"collection_date\" or .TAG==\"collection date\")|.VALUE' \\\n    SRA.json | tee OUT_COLLECTION_DATE\njq -r \\\n    '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.SAMPLE_ATTRIBUTES.SAMPLE_ATTRIBUTE[]|select(.TAG == \"strain\")|.VALUE' \\\n    SRA.json | tee OUT_STRAIN\njq -r \\\n    '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.SAMPLE_ATTRIBUTES.SAMPLE_ATTRIBUTE[]|select(.TAG == \"collected_by\" or .TAG == \"collecting institution\")|.VALUE' \\\n    SRA.json | tee OUT_COLLECTED_BY\njq -r \\\n    '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.SAMPLE_ATTRIBUTES.SAMPLE_ATTRIBUTE[]|select(.TAG == \"geo_loc_name\" or .TAG == \"geographic location (country and/or sea)\")|.VALUE' \\\n    SRA.json | tee OUT_GEO_LOC\njq -r \\\n    '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.DESIGN.LIBRARY_DESCRIPTOR.LIBRARY_STRATEGY' \\\n    SRA.json | tee OUT_LIBRARY_STRATEGY\n\nset -e\npython3 << CODE\nimport json\nwith open('SRA.json', 'rt') as inf:\n    meta = json.load(inf)\n# reorganize to look more like a biosample attributes tsv\nbiosample = dict((x['TAG'],x['VALUE']) for x in meta['EXPERIMENT_PACKAGE_SET']['EXPERIMENT_PACKAGE']['SAMPLE']['SAMPLE_ATTRIBUTES']['SAMPLE_ATTRIBUTE'])\nbiosample['accession'] = meta['EXPERIMENT_PACKAGE_SET']['EXPERIMENT_PACKAGE']['SAMPLE']['IDENTIFIERS']['EXTERNAL_ID']['content']\nbiosample['message'] = 'Successfully loaded'\nbiosample['bioproject_accession'] = meta['EXPERIMENT_PACKAGE_SET']['EXPERIMENT_PACKAGE']['STUDY']['IDENTIFIERS']['EXTERNAL_ID']['content']\nbiosample['sample_name'] = biosample['isolate']\nfor k,v in biosample.items():\n    if v == 'not provided':\n        biosample[k] = ''\n\n# British to American conversions (NCBI vs ENA)\nus_to_uk = {\n    'sample_name': 'Sample Name',\n    'isolate': 'Sample Name',\n    'collected_by': 'collecting institution',\n    'collection_date': 'collection date',\n    'geo_loc_name': 'geographic location (country and/or sea)',\n    'host': 'host scientific name',\n}\nfor key_us, key_uk in us_to_uk.items():\n    if not biosample.get(key_us,''):\n        biosample[key_us] = biosample.get(key_uk,'')\n\n# write outputs\nwith open('SRR13379731-biosample_attributes.json', 'wt') as outf:\n    json.dump(biosample, outf)\nCODE",
         shardIndex: -1,
         outputs: {
-          library_id: 'UT-UPHL-2012556126',
+          library_id: 'VAL-KDSC-2012556126',
           sample_collection_date: '2020-11-30',
-          biosample_accession: 'SAMN17251688',
+          biosample_accession: 'SSM32424324',
           run_date: '2022-06-22',
           sra_metadata:
             'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/SRR13379731.json',
           library_strategy: 'AMPLICON',
           num_reads: 552132,
-          sequencing_center: 'UPHL_ID',
+          sequencing_center: 'SQLCT',
           reads_ubam:
             'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/SRR13379731.bam',
           sample_strain: 'SARS-CoV-2/USA/44165/2020',
           biosample_attributes_json:
             'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/SRR13379731-biosample_attributes.json',
-          sample_geo_loc: 'USA: Utah',
-          sequencing_platform: 'ILLUMINA',
-          sample_collected_by: 'Utah Public Health Laboratory',
+          sample_geo_loc: 'USA',
+          sequencing_platform: 'Platform Company',
+          sample_collected_by: 'Random',
           sequencing_platform_model: 'NextSeq 550'
         },
         runtimeAttributes: {
@@ -72,7 +72,7 @@ export const metadata = {
         inputs: {
           docker: 'quay.io/broadinstitute/ncbi-tools:2.10.7.10',
           disk_size: 750,
-          SRA_ID: 'SRR13379731',
+          SRA_ID: 'sfkjl23k',
           machine_mem_gb: null
         },
         returnCode: 0,
@@ -82,7 +82,7 @@ export const metadata = {
         backendStatus: 'Complete',
         compressedDockerSize: 1339143280,
         end: '2023-05-24T11:22:31.784Z',
-        dockerImageUsed: 'quay.io/broadinstitute/ncbi-tools@sha256:c6228528a9fa7d3abd78d40821231ec49c122f8c10bb27ae603540c46fc05797',
+        dockerImageUsed: 'docker_img_uri',
         stderr:
           'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/stderr',
         callRoot:
@@ -128,14 +128,14 @@ export const metadata = {
       'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/SRR13379731.json',
     'fetch_sra_to_bam.reads_ubam':
       'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value/call-Fetch_SRA_to_BAM/execution/SRR13379731.bam',
-    'fetch_sra_to_bam.biosample_accession': 'SAMN17251688',
-    'fetch_sra_to_bam.sample_geo_loc': 'USA: Utah',
+    'fetch_sra_to_bam.biosample_accession': 'kljkl2kj',
+    'fetch_sra_to_bam.sample_geo_loc': 'USA',
     'fetch_sra_to_bam.sample_collection_date': '2020-11-30',
-    'fetch_sra_to_bam.sequencing_center': 'UPHL_ID',
-    'fetch_sra_to_bam.sequencing_platform': 'ILLUMINA',
-    'fetch_sra_to_bam.library_id': 'UT-UPHL-2012556126',
+    'fetch_sra_to_bam.sequencing_center': 'SEQ_CENTER',
+    'fetch_sra_to_bam.sequencing_platform': 'PLATFORM COMPANY',
+    'fetch_sra_to_bam.library_id': 'ST-VALUE-2012556126',
     'fetch_sra_to_bam.run_date': '2022-06-22',
-    'fetch_sra_to_bam.sample_collected_by': 'Utah Public Health Laboratory',
+    'fetch_sra_to_bam.sample_collected_by': 'Random lab',
     'fetch_sra_to_bam.sample_strain': 'SARS-CoV-2/USA/44165/2020',
     'fetch_sra_to_bam.sequencing_platform_model': 'NextSeq 550'
   },
@@ -143,12 +143,6 @@ export const metadata = {
     'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/fetch_sra_to_bam/more-random-value',
   actualWorkflowLanguage: 'WDL',
   status: 'Succeeded',
-  failures: [
-    {
-      message: 'InjectionManagerFactory not found.',
-      causedBy: []
-    }
-  ],
   workflowLog:
     'https://kj4l5k3hjklk3jlk43jl3kj43lkj3l4kj3.blob.core.windows.net/sc-random-value/workspace-services/cbas/terra-app-other-random-value/cromwell-workflow-logs/workflow.more-random-value.log',
   end: '2023-05-22T11:22:33.705Z',

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -93,6 +93,10 @@ const Cromwell = signal => ({
         const keyParams = qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })
         const res = await fetchCromwell(`${workflowId}/metadata?${keyParams}`, { signal, method: 'GET' })
         return res.json()
+      },
+      failedTasks: async () => {
+        const res = await fetchCromwell(`${workflowId}/metadata/failed-jobs`, { signal, method: 'GET' })
+        return res.json()
       }
     }
   }

--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -30,7 +30,7 @@ export const organizeCallTableData = (metadataCalls = {}, failedTaskCalls = {}) 
   if (!isEmpty(failedTaskTableData)) {
     const successfulMetadata = filter(({ statusObj }) => {
       const { id } = statusObj
-      return id?.toLocaleLowerCase() === 'succeeded'
+      return id?.toLocaleLowerCase() !== 'failed'
     }, metadataTableData)
     return successfulMetadata.concat(failedTaskTableData)
   }
@@ -192,7 +192,7 @@ export const RunDetails = ({ submissionId, workflowId }) => {
           ])
         ])
       ],
-      () => h(Fragment, {}, [
+      () => div({ role: 'main' }, [
         div({ style: { padding: '1rem 2rem 2rem' } }, [header]),
         div({ 'data-testid': 'details-top-container', style: { display: 'flex', justifyContent: 'space-between', padding: '1rem 2rem 2rem' } }, [
           h(WorkflowInfoBox, { workflow }, []),


### PR DESCRIPTION
Addresses [WX-1110](https://broadworkbench.atlassian.net/browse/WX-1110)

PR adds the front-end implementation for this ticket. This ticket will utilize the new Cromwell endpoint to fetch failed tasks for the Workflow Details page if a workflow failed. This means adding a new Ajax method to hit the new endpoint and a new processing method to format the failed task metadata for the CallTable.

[WX-1110]: https://broadworkbench.atlassian.net/browse/WX-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ