### PR TITLE
[WX-1220] Gracefully handle failedTasks fetch on RunDetails.js

### DIFF
--- a/src/pages/RunDetails.js
+++ b/src/pages/RunDetails.js
@@ -107,7 +107,11 @@ export const RunDetails = ({ submissionId, workflowId }) => {
     let failedTasks = {}
     const metadata = await fetchMetadata(workflowId)
     if (metadata?.status?.toLocaleLowerCase() === 'failed') {
-      failedTasks = await Ajax(signal).Cromwell.workflows(workflowId).failedTasks()
+      try {
+        failedTasks = await Ajax(signal).Cromwell.workflows(workflowId).failedTasks()
+      } catch (error) {
+        //do nothing, failure here means that user may not have access to an updated version of Cromwell
+      }
     }
     const { workflowName } = metadata
     isNil(updateWorkflowPath) && setWorkflow(metadata)

--- a/src/pages/RunDetails.test.js
+++ b/src/pages/RunDetails.test.js
@@ -573,10 +573,10 @@ describe('RunDetails - render smoke test', () => {
             },
             failedTasks: () => {
               return Promise.reject()
-            },
-          };
-        },
-      },
+            }
+          }
+        }
+      }
     })
 
     Ajax.mockImplementation(() => {


### PR DESCRIPTION
Addresses [WX-1220](https://broadworkbench.atlassian.net/browse/WX-1220)

PR wraps the request against Cromwell's `failed-tasks` endpoint in a try-catch to gracefully handle failures in situations where a workspace is using an older Cromwell version (or specifically a version that does not have the endpoint present).

[WX-1220]: https://broadworkbench.atlassian.net/browse/WX-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ